### PR TITLE
Fix casting issue

### DIFF
--- a/linkedlist.mod/linkedlist.bmx
+++ b/linkedlist.mod/linkedlist.bmx
@@ -429,7 +429,7 @@ Type TList
 ?Threaded
 			LockMutex(_mutex)
 ?
-		Local enum:TListEnum=TListEnum._pool.RemoveFirst()
+		Local enum:TListEnum=TListEnum(TListEnum._pool.RemoveFirst())
 ?Threaded
 			UnlockMutex(_mutex)
 ?


### PR DESCRIPTION
making brl.linkedlist fails if you don't explicitly cast TListEnum._pool.RemoveFirst() to TListEnum.
