### PR TITLE
[ifc] Interface Implementation

### DIFF
--- a/blitz.mod/blitz.bmx
+++ b/blitz.mod/blitz.bmx
@@ -8,12 +8,15 @@ bbdoc: BASIC/BlitzMax runtime
 End Rem
 Module BRL.Blitz
 
-ModuleInfo "Version: 1.18"
+ModuleInfo "Version: 1.19"
 ModuleInfo "Author: Mark Sibly"
 ModuleInfo "License: zlib/libpng"
 ModuleInfo "Copyright: Blitz Research Ltd"
 ModuleInfo "Modserver: BRL"
 
+ModuleInfo "History: 1.19"
+ModuleInfo "History: Added interfaces."
+ModuleInfo "History: Added Interface and EndInterface keyword docs"
 ModuleInfo "History: 1.18"
 ModuleInfo "History: WriteStdout and WriteStderr now write UTF-8"
 ModuleInfo "History: 1.17 Release"
@@ -927,5 +930,15 @@ End Rem
 Rem
 bbdoc: Create a string of length 1 with a character code
 keyword: "Chr"
+End Rem
+
+Rem
+bbdoc: Begin a user defined Interface declaration
+keyword: "Interface"
+End Rem
+
+Rem
+bbdoc: End a user defined Interface declaration
+keyword: "EndInterface"
 End Rem
 

--- a/blitz.mod/blitz_array.c
+++ b/blitz.mod/blitz_array.c
@@ -22,9 +22,9 @@ BBClass bbArrayClass={
 	bbObjectToString,
 	bbObjectCompare,
 	bbObjectSendMessage,
-	bbObjectReserved,
-	bbObjectReserved,
-	bbObjectReserved,
+	0,
+	0,
+	0,
 	
 	bbArraySort,
 	bbArrayDimensions

--- a/blitz.mod/blitz_object.c
+++ b/blitz.mod/blitz_object.c
@@ -22,9 +22,9 @@ BBClass bbObjectClass={
 	bbObjectToString,
 	bbObjectCompare,
 	bbObjectSendMessage,
-	bbObjectReserved,
-	bbObjectReserved,
-	bbObjectReserved,
+	0,
+	0,
+	0,
 };
 
 BBObject bbNullObject={
@@ -111,4 +111,50 @@ void bbObjectRegisterType( BBClass *clas ){
 BBClass **bbObjectRegisteredTypes( int *count ){
 	*count=reg_put-reg_base;
 	return reg_base;
+}
+
+BBObject * bbInterfaceDowncast(BBOBJECT o, BBINTERFACE ifc) {
+	int i;
+
+	BBCLASS superclas = o->clas;
+
+	do {
+		BBCLASS clas = superclas;
+		superclas = clas->super;
+
+		BBINTERFACEOFFSETS offsets      = clas->ifc_offsets;
+		if (offsets) {
+			for (i = clas->ifc_size; i; i--) {
+				if (offsets->ifc == ifc) {
+					return o;
+				}
+				offsets++;
+			}
+		}
+	} while (superclas);
+
+	return &bbNullObject;
+}
+
+void * bbObjectInterface(BBOBJECT o, BBINTERFACE ifc) {
+	int i;
+
+	BBCLASS superclas = o->clas;
+
+	do {
+		BBCLASS clas = superclas;
+		superclas = clas->super;
+
+		BBINTERFACEOFFSETS offsets      = clas->ifc_offsets;
+		if (offsets) {
+			for (i = clas->ifc_size; i; i--) {
+				if (offsets->ifc == ifc) {
+					return (char*) clas->ifc_vtable + offsets->offset;
+				}
+				offsets++;
+			}
+		}
+	} while (superclas);
+
+	return &bbNullObject;
 }

--- a/blitz.mod/blitz_object.h
+++ b/blitz.mod/blitz_object.h
@@ -27,10 +27,11 @@ struct BBClass{
 	BBString*	(*ToString)( BBObject *x );
 	int		(*Compare)( BBObject *x,BBObject *y );
 	BBObject*	(*SendMessage)( BBObject *m,BBObject *s );
-	void		(*_reserved1_)();
-	void		(*_reserved2_)();
-	void		(*_reserved3_)();
-	
+
+	BBINTERFACEOFFSETS ifc_offsets;
+	void * ifc_vtable;
+	int ifc_size;
+
 	void*	vfns[32];
 };
 
@@ -38,6 +39,15 @@ struct BBObject{
 	//extends BBGCMem
 	BBClass*	clas;
 	//int		refs;
+};
+
+struct BBInterface {
+	const char *name;
+};
+
+struct BBInterfaceOffsets {
+    BBINTERFACE ifc;
+    int offset;
 };
 
 extern	BBClass bbObjectClass;
@@ -59,6 +69,9 @@ BBObject*	bbObjectDowncast( BBObject *o,BBClass *t );
 
 void		bbObjectRegisterType( BBClass *clas );
 BBClass**	bbObjectRegisteredTypes( int *count );
+
+BBObject * bbInterfaceDowncast(BBOBJECT o, BBINTERFACE ifc);
+void * bbObjectInterface(BBOBJECT o, BBINTERFACE ifc);
 
 #ifdef __cplusplus
 }

--- a/blitz.mod/blitz_string.c
+++ b/blitz.mod/blitz_string.c
@@ -24,9 +24,9 @@ BBClass bbStringClass={
 	(BBString*(*)(BBObject*))bbStringToString,
 	(int(*)(BBObject*,BBObject*))bbStringCompare,
 	bbObjectSendMessage,
-	bbObjectReserved,
-	bbObjectReserved,
-	bbObjectReserved,
+	0,
+	0,
+	0,
 	
 	bbStringFind,
 	bbStringFindLast,

--- a/blitz.mod/blitz_types.h
+++ b/blitz.mod/blitz_types.h
@@ -20,6 +20,8 @@ typedef struct BBClass	BBClass;
 typedef struct BBObject	BBObject;
 typedef struct BBString	BBString;
 typedef struct BBArray	BBArray;
+typedef struct BBInterface BBInterface;
+typedef struct BBInterfaceOffsets BBInterfaceOffsets;
 
 typedef unsigned char	BBBYTE;
 typedef unsigned short	BBSHORT;
@@ -31,6 +33,8 @@ typedef BBClass*		BBCLASS;
 typedef BBObject*		BBOBJECT;
 typedef BBString*		BBSTRING;
 typedef BBArray*		BBARRAY;
+typedef BBInterface*	BBINTERFACE;
+typedef BBInterfaceOffsets * BBINTERFACEOFFSETS;
 
 extern const char *bbVoidTypeTag;	//"?"
 extern const char *bbByteTypeTag;	//"b"


### PR DESCRIPTION
Adds Interfaces to BlitzMax.

Interfaces can be created using the following :
```blitzmax
Interface myInterface
  Method myMethod()
End Interface

Type myType Implements myInterface
  Method myMethod()
    ' implement here
  End Method
End Type
````

Interfaces can be extend other interfaces :
```blitzmax
Interface myOtherInterface Extends myInterface
  Method anotherMethod()
End Interface
```

Types can implement multiple interfaces :
```blitzmax
Type myBigType Implements myInterface, anotherInterface
  Method myMethod()
  End Method

  Method moreMethod()
  End Method
End Type
```

Abstract types which implement an interface can elect not to implement those methods. Its concrete subclass however, will need to implement any methods in the hierarchy that haven't.