### PR TITLE
Fix: OggLoader.mod loads ogg files again with corrected pub.OggVorbis

### DIFF
--- a/oggloader.mod/oggloader.bmx
+++ b/oggloader.mod/oggloader.bmx
@@ -61,9 +61,10 @@ Type TAudioSampleLoaderOGG Extends TAudioSampleLoader
 		Local size=samples*2*channels
 		Local sample:TAudioSample=TAudioSample.Create( samples,freq,format )
 
-		Local err=Read_Ogg( ogg,sample.samples,size )
+		'negative amounts indicate an error, 0 = EOF, >0 = amount of bytes
+		Local bytesRead:int = Read_Ogg( ogg,sample.samples,size )
 		Read_Ogg( ogg,Null,0 )
-		If err Return
+		If bytesRead <= 0 Return
 
 		Return sample
 


### PR DESCRIPTION
Before fix:
Ogg loading failed with pub.mod/OggVorbis.mod/oggdecoder.c: Read_Ogg() being corrected to return amount of read bytes.
OggLoader just checked for "<> 0" results, which then of course fails. As Only EOF (0) and errors (<0) are of interest, the check was adjusted to allow "old" and "correct" behaviour of Read_Ogg()