### PR TITLE
fixed bug with intrinsic array values not showing correctly

### DIFF
--- a/appstub.mod/debugger.stdio.glue.c
+++ b/appstub.mod/debugger.stdio.glue.c
@@ -92,6 +92,10 @@ void bmx_debugger_DebugDecl_ArrayDeclIndexedPart(struct BBDebugDecl * decl, BBAr
 		case 'l':size=8;break;
 		case 'y':size=8;break;
 		case 'd':size=8;break;
+		case 'h':size=8;break;
+		case 'j':size=16;break;
+		case 'k':size=16;break;
+		case 'm':size=16;break;
 		case '*':size=sizeof(void*);break;
 		case ':':size=sizeof(void*);break;
 		case '$':size=sizeof(void*);break;


### PR DESCRIPTION
The intrinsic values in an array that contains intrinsic types weren't showing correctly for array element slots greater than 0.