### PR TITLE
removed byte ptr dereference in case its an OS handle, better null po…

### DIFF
--- a/appstub.mod/debugger_mt.stdio.bmx
+++ b/appstub.mod/debugger_mt.stdio.bmx
@@ -408,6 +408,10 @@ Function DebugDerefPointer$(decl:Int Ptr, pointer:Int Ptr)
 	Forever
 
 	For Local i:Int = 0 Until count
+		' Null
+		If pointer = 0 Then
+			Return " {-}"
+		End If
 ?ptr64
 		pointer = Long Ptr (Varptr pointer)[0]
 ?Not ptr64
@@ -415,19 +419,14 @@ Function DebugDerefPointer$(decl:Int Ptr, pointer:Int Ptr)
 ?
 	Next
 
-	' Null
-	If pointer = 0 Then
-		Return " {-}"
-	End If
-
 	Local value:String
 	Select datatype
 	Case "Byte"
-		value = Byte Ptr (Varptr pointer)[0]
-		Return " {"+value+"}"
+		' don't reference a byte ptr in case its an OS handle ( which isn't a memory address! )
+		Return " {-}"
 
 	Case "Short"
-		value = Short Ptr (Varptr pointer)[0]
+		value = Short (Short  Ptr (Varptr pointer)[0])
 		Return " {"+value+"}"
 
 	Case "Int"
@@ -439,7 +438,7 @@ Function DebugDerefPointer$(decl:Int Ptr, pointer:Int Ptr)
 		Return " {"+value+"}"
 
 	Case "Float"
-		value = Float Ptr (Varptr pointer)[0]
+		value = Float (Float Ptr (pointer)[0])
 		Return " {"+value+"}"
 		
 	Case "Double"


### PR DESCRIPTION
Hey,

I've noticed, specifically for windows. that you use 'byte ptr' for OS handles. This raises an issue regarding this modification of de-referencing pointers because an OS handle isn't actually a pointer, its a handle value that the OS uses as opposed to a memory address, it maybe an index into a table or something similar or maybe the high/low words would refer to a mempage or something else entirely, but the point being that an OS handle isn't actually a memory pointer that can be de-referenced. So when using this modification it will EAV when trying to de-reference an OS handle value.

I suggest, as a byte ptr is used for OS handles, to remove the de-referencing part for the byte ptr.
Also I put your 'null' check in the loop for 'pointers to pointers to...' just to make sure it doesn't get a null in the middle there somewhere.