### PR TITLE
prevent segfault with derefencing pointers to pointers that point to null

### DIFF
--- a/appstub.mod/debugger_mt.stdio.bmx
+++ b/appstub.mod/debugger_mt.stdio.bmx
@@ -429,6 +429,11 @@ Function DebugDerefPointer$(decl:Int Ptr, pointer:Int Ptr)
 ?
 	Next
 
+	' make sure the final pointer is not null
+	If pointer = 0 
+		Return " {-}"
+	EndIf
+
 	Local value:String
 	Select datatype
 	Case "Byte"


### PR DESCRIPTION
There was a very subtle bug that was introduced in a feature proposed by myself involving dereferencing pointers where the final pointed to pointer could be null.
This request fixes that bug. It's the issue that I posted at http://www.blitzbasic.com/Community/posts.php?topic=106571