### PR TITLE
fixes #220

### DIFF
--- a/appstub.mod/debugger_mt.stdio.bmx
+++ b/appstub.mod/debugger_mt.stdio.bmx
@@ -187,6 +187,7 @@ Function TypeName$( tag$ Var )
 		Return TypeName( tag )+t+")"
 	End Select
 
+	If Not tag.length Return ""
 	DebugError "Invalid debug typetag:"+t
 
 End Function


### PR DESCRIPTION
Hiya,

This should fix up the 'invalid debug typetag' error in issue #220 related to function pointers to functions that have no parameters.