### PR TITLE
Fix: TMap.Copy() now only copies _root if there were entries in the map

### DIFF
--- a/map.mod/map.bmx
+++ b/map.mod/map.bmx
@@ -293,7 +293,10 @@ Type TMap
 	
 	Method Copy:TMap()
 		Local map:TMap=New TMap
-		map._root=_root.Copy( nil )
+		'avoid copying an empty map (_root = nil there), else it borks "eachin"
+		if _root <> nil
+			map._root=_root.Copy( nil )
+		endif
 		Return map
 	End Method
 


### PR DESCRIPTION
There is also "IsEmpty()" which could be used to check whether a copy is really needed, but if TMap is somewhen updated, "IsEmpty()" might return True while a "copy" is no longer allowed to get skipped.

Closes bmx-ng/brl.mod/issues/41