### PR TITLE
Change GCRelease parameter to Byte Ptr

### DIFF
--- a/blitz.mod/blitz.bmx
+++ b/blitz.mod/blitz.bmx
@@ -482,7 +482,7 @@ Function GCRetain(obj:Object)="bbGCRetain"
 Rem
 bbdoc: Releases a reference from the specified #Object.
 End Rem
-Function GCRelease(obj:Object)="bbGCRelease"
+Function GCRelease(obj:Byte Ptr)="void bbGCRelease(BBObject*)!"
 
 Rem
 bbdoc: Returns #True if the current thread is registered with the garbage collector.


### PR DESCRIPTION
Currently, the `GCRelease` function exposed in `BRL.Blitz` takes a parameter of type `Object`, which appears to make it useless. Afaik `GCRetain` exists to allow objects to survive garbage collection despite being unreachable via references. But with an `Object` parameter, `GCRelease` cannot be called on any object unless a reference to it still exists (which, in turn, makes the `GCRetain` call unnecessary). It should take a `Byte Ptr` instead.