### PR TITLE
Fix: [FreeTypeFont.mod] Restore stream position after loading

### DIFF
--- a/freetypefont.mod/freetypefont.bmx
+++ b/freetypefont.mod/freetypefont.bmx
@@ -169,12 +169,21 @@ Type TFreeTypeFont Extends BRL.Font.TFont
 			Local data:Byte[1024 * 90]
 			Local dataSize:Int
 
+			'backup old stream position to set it back to it afterwards
+			'Pos() returns -1 for non-seekable-streams
+			Local oldStreamPos:int = stream.Pos()
+			If oldStreamPos > -1 Then stream.Seek(0)
+			
 			While Not stream.Eof()
 				If dataSize = data.length
 					data = data[..dataSize * 3 / 2]
 				EndIf
 				dataSize :+ stream.Read( (Byte Ptr data) + dataSize, data.length - dataSize )
 			Wend
+
+			'restore stream position
+			If oldStreamPos > -1 Then stream.Seek(oldStreamPos)
+
 			If dataSize <> data.length
 				data = data[..dataSize]
 			EndIf


### PR DESCRIPTION
Without restoring stream positions you might come into trouble when trying to load multipe fonts with one single stream (eg a bankstream or ramstream to something).

If a stream wasn't seekable then Pos() is ought to return -1.