### PR TITLE
Fix: [Brl.D3D9xxx] Reapplied SuperStrict-corrections

### DIFF
--- a/d3d9max2d.mod/d3d9max2d.bmx
+++ b/d3d9max2d.mod/d3d9max2d.bmx
@@ -717,7 +717,7 @@ Type TD3D9RenderImage Extends TRenderImage
 			_d3ddev.SetRenderState(D3DRS_SCISSORTESTENABLE, False)
 		Else
 			_d3ddev.SetRenderState(D3DRS_SCISSORTESTENABLE, True)
-			Local rect[] = [x , y, x + width, y + height]
+			Local rect:Int[] = [x , y, x + width, y + height]
 			_d3ddev.SetScissorRect(rect)
 		EndIf
 

--- a/dxgraphics.mod/d3d9graphics.bmx
+++ b/dxgraphics.mod/d3d9graphics.bmx
@@ -83,7 +83,7 @@ Function OpenD3DDevice:Int( hwnd:Byte Ptr,width:Int,height:Int,depth:Int,hertz:I
 	
 	'_d3dDev' = New IDirect3DDevice9
 
-	Function CheckDepthFormat(format:Int)
+	Function CheckDepthFormat:Int(format:Int)
 	    Return _d3d.CheckDeviceFormat(0,D3DDEVTYPE_HAL,D3DFMT_X8R8G8B8,D3DUSAGE_DEPTHSTENCIL,D3DRTYPE_SURFACE,format)=D3D_OK
 	End Function
 


### PR DESCRIPTION
Must have slipped through in my PR for r2t.

Afterwards current brl.mod compiles completely with current BCC/BMK again.