### PR TITLE
Some tweaks to TLinkedList

### DIFF
--- a/collections.mod/linkedlist.bmx
+++ b/collections.mod/linkedlist.bmx
@@ -103,7 +103,9 @@ Public
 	EndRem
 	Method Shift:T()
 		Local val:T = FirstValue()
-		RemoveFirst()
+		If val
+			RemoveFirst()
+		EndIf
 		Return val
 	EndMethod
 	
@@ -112,7 +114,9 @@ Public
 	EndRem
 	Method Pop:T()
 		Local val:T = LastValue()
-		RemoveLast()
+		If val
+			RemoveLast()
+		EndIf
 		Return val
 	EndMethod
 	
@@ -331,23 +335,27 @@ Public
 	Rem
 	bbdoc: Removes the node at the start of the #TLinkedList.
 	End Rem
-	Method RemoveFirst()
+	Method RemoveFirst:Int()
 		If Not head Then
-			Throw New TInvalidOperationException("list is empty")
+			Return False
 		End If
 		
 		RemoveNode(head)
+		
+		Return True
 	End Method
 	
 	Rem
 	bbdoc: Removes the node at the end of the #TLinkedList.
 	End Rem
-	Method RemoveLast()
+	Method RemoveLast:Int()
 		If Not head Then
-			Throw New TInvalidOperationException("list is empty")
+			Return False
 		End If
 		
-		RemoveNode(head.previousNode)		
+		RemoveNode(head.previousNode)
+		
+		Return True
 	End Method
 
 	Rem
@@ -444,8 +452,9 @@ Private
 				head = node.nextNode
 			End If
 			node.Clear()
-			size :- 1
 		End If
+		
+		size :- 1
 	End Method
 	
 	Method CreateHead(node:TLinkedListNode<T>)


### PR DESCRIPTION
IMO the exceptions in RemoveFirst and RemoveLast are unnecessary.

And the size :- 1 in RemoveNode fixes a bug where Count() returns the wrong number after removing the last item - not sure if it screws something up but I think not.