### PR TITLE
LinkedList: Change assignment order in TLink.remove

### DIFF
--- a/linkedlist.mod/linkedlist.bmx
+++ b/linkedlist.mod/linkedlist.bmx
@@ -66,9 +66,9 @@ Type TLink
 	bbdoc: Removes the link from the List.
 	End Rem
 	Method Remove()
-		_value=Null
-		_succ._pred=_pred
 		_pred._succ=_succ
+		_succ._pred=_pred
+		_value=Null
 	End Method
 
 End Type


### PR DESCRIPTION
In TVTower, I experience sporadic segmentation faults. Some of them could be traced to null access in the "contains" method of TLinkedList where the link value is compared to the parameter object, but the link value is null. This probably happens because several threads access the same list, concurrently changing and iterating over it.

With this change, the link's value is set to null only after the links of the neighbour nodes have been updated. This reduces the chance of a thread iterating a list currently being modified to look at a link whose value was set to null.