### PR TITLE
Fix: IsProbablyUTF8() now works with multi-bytes as last char

### DIFF
--- a/textstream.mod/textstream.bmx
+++ b/textstream.mod/textstream.bmx
@@ -512,7 +512,10 @@ Function IsProbablyUTF8:Int(data:Byte Ptr, size:Int)
 	Next
 
 	If count Then
-		Return False
+		' If there was no new-line or non-multi-byte-character at the 
+		' end of the buffer then count will be > 0. So we also have to
+		' check if we can decode the remaining buffer content.
+		If Decode(buf, count) = -1 Then Return False
 	End If
 	
 	Return True


### PR DESCRIPTION
Prior: If a data buffer contained an UTF8/multi-byte char at the end (so no newline char or ascii-char at the end) it was not detected as UTF8 (and so eg `LoadText()` failed to decode properly).

Sample code and test files attached:
[loadtext.zip](https://github.com/user-attachments/files/19245401/loadtext.zip)
