### PR TITLE
Adds AtStart function for startup queue

### DIFF
--- a/blitz.mod/blitz.bmx
+++ b/blitz.mod/blitz.bmx
@@ -124,6 +124,7 @@ Import "blitz_unicode.c"
 Import "blitz_enum.c"
 Import "blitz_coverage.c"
 Import "blitz_strto.c"
+Import "blitz_atstart.c"
 Import "blitz_string_ex.cpp"
 
 ?coverage
@@ -804,6 +805,14 @@ Function ObjectIsString:Int(obj:Object)="int bbObjectIsString(BBOBJECT)!"
 
 Function DumpObjectCounts(buffer:Byte Ptr, size:Int, includeZeros:Int)="void bbObjectDumpInstanceCounts(char *, int, int)!"
 Global CountObjectInstances:Int="bbCountInstances"
+
+Rem
+bbdoc: Adds a function to the startup queue, optionally with a priority.
+about: After all modules have been loaded, and before the main loop starts, the functions
+in the startup queue are called in order of priority, with higher priority functions being
+called first.
+End Rem
+Function AtStart:Int(func(), priority:Int = 0)="bbAtstart"
 
 End Extern
 

--- a/blitz.mod/blitz.h
+++ b/blitz.mod/blitz.h
@@ -41,6 +41,7 @@
 #include "blitz_enum.h"
 #include "blitz_coverage.h"
 #include "blitz_strto.h"
+#include "blitz_atstart.h"
 
 #ifdef __cplusplus
 extern "C"{

--- a/blitz.mod/blitz_atstart.c
+++ b/blitz.mod/blitz_atstart.c
@@ -1,0 +1,58 @@
+#include <stdlib.h>
+#include "blitz_atstart.h"
+
+typedef struct bb_node {
+    bb_startup_fn fn;
+    int priority;
+    struct bb_node *next;
+} bb_node;
+
+static bb_node *g_head = NULL; // sorted: higher priority first, FIFO within ties
+static int      g_ran  = 0; // has the startup pass completed?
+
+int bbAtstart(bb_startup_fn fn, int priority) {
+    if (!fn) {
+        return 0;
+    }
+
+    // If startup already ran, run immediately.
+    if (g_ran) {
+        fn(); return 1;
+    }
+
+    bb_node *n = (bb_node *)malloc(sizeof(*n));
+    if (!n) {
+        return 0;
+    }
+    n->fn = fn; n->priority = priority; n->next = NULL;
+
+    // Insert at head if list is empty or higher priority than head.
+    if (!g_head || priority > g_head->priority) {
+        n->next = g_head;
+        g_head = n;
+        return 1;
+    }
+
+    // Walk past strictly higher priorities...
+    bb_node *cur = g_head;
+    while (cur->next && cur->next->priority > priority) cur = cur->next;
+    // ...then past equals to keep FIFO for ties.
+    while (cur->next && cur->next->priority == priority) cur = cur->next;
+
+    n->next = cur->next;
+    cur->next = n;
+    return 1;
+}
+
+void bbRunAtstart(void) {
+    // Pop-and-run until empty.
+    while (g_head) {
+        bb_node *n = g_head;
+        g_head = n->next;
+
+        bb_startup_fn fn = n->fn;
+        free(n);
+        fn();
+    }
+    g_ran = 1;
+}

--- a/blitz.mod/blitz_atstart.h
+++ b/blitz.mod/blitz_atstart.h
@@ -1,0 +1,18 @@
+
+#ifndef BLITZ_ATSTART_H
+#define BLITZ_ATSTART_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*bb_startup_fn)(void);
+
+int  bbAtstart(bb_startup_fn fn, int priority); /* returns 1 on success */
+void bbRunAtstart(void); /* run once, highest priority first */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/reflection.mod/reflection.bmx
+++ b/reflection.mod/reflection.bmx
@@ -110,11 +110,12 @@ Extern
 	Function bbDebugDeclIsFlagsEnum:Byte(decl:Byte Ptr)
 	Function bbDebugDeclReflectionWrapper:Byte Ptr(decl:Byte Ptr)
 	Function bbDebugDeclNext:Byte Ptr(decl:Byte Ptr)
-	
+	?x64
 	Global DebugScopePtrInt128:Byte Ptr = "debugScopePtrInt128"
 	Global DebugScopePtrFloat64:Byte Ptr = "debugScopePtrFloat64"
 	Global DebugScopePtrFloat128:Byte Ptr = "debugScopePtrFloat128"
 	Global DebugScopePtrDouble128:Byte Ptr = "debugScopePtrDouble128"
+	?
 End Extern
 
 
@@ -4069,7 +4070,7 @@ Type TTypeId Extends TMember
 	bbdoc: Get type by name
 	End Rem
 	Function ForName:TTypeId(name:String)
-		_Update
+
 		Return ForName_(name.ToLower())
 		
 		Function ForName_:TTypeId(name:String)
@@ -4162,7 +4163,6 @@ Type TTypeId Extends TMember
 	bbdoc: Get type by object
 	End Rem	
 	Function ForObject:TTypeId(obj:Object)
-		_Update
 		Local box:TBoxedValue = TBoxedValue(obj)
 		If box Then Return box.typeId
 		Local class:Byte Ptr = bbRefGetObjectClass(obj)
@@ -4178,7 +4178,6 @@ Type TTypeId Extends TMember
 	bbdoc: Get list of all data types currently used in this program
 	End Rem
 	Function EnumTypes:TList()
-		_Update
 		Local list:TList = New TList
 		For Local t:TTypeId = EachIn _nameMap.Values()
 			list.AddLast t
@@ -4191,7 +4190,6 @@ Type TTypeId Extends TMember
 	about: Does not include array types.
 	End Rem
 	Function EnumClasses:TList()
-		_Update
 		Local list:TList = New TList
 		For Local t:TTypeId = EachIn _classMap.Values()
 			If t._super = ArrayTypeId Then Continue	' filter out Object[]
@@ -4204,7 +4202,6 @@ Type TTypeId Extends TMember
 	bbdoc: Get a list of all interface types
 	End Rem
 	Function EnumInterfaces:TList()
-		_Update
 		Local list:TList = New TList
 		For Local t:TTypeId = EachIn _interfaceMap.Values()
 			list.AddFirst t
@@ -4216,7 +4213,6 @@ Type TTypeId Extends TMember
 	bbdoc: Get a list of all struct types
 	End Rem
 	Function EnumStructs:TList()
-		_Update
 		Local list:TList = New TList
 		For Local t:TTypeId = EachIn _structMap.Values()
 			list.AddFirst t
@@ -4228,7 +4224,6 @@ Type TTypeId Extends TMember
 	bbdoc: Get a list of all enum types
 	End Rem
 	Function EnumEnums:TList()
-		_Update
 		Local list:TList = New TList
 		For Local t:TTypeId = EachIn _enumMap.Values()
 			list.AddFirst t
@@ -4367,8 +4362,12 @@ Type TTypeId Extends TMember
 		_enumMap.Insert scope, Self
 		Return Self
 	End Method
-	
-	Function _Update()
+
+	Global _inited:Int = False
+
+	Function _Initialize()
+		If _inited Then Return
+		_inited = True
 		Try
 			ReflectionMutex.Lock
 			Local ccount:Int
@@ -4536,4 +4535,5 @@ Type TTypeId Extends TMember
 	
 End Type
 
-
+' Initialize reflection system
+AtStart(TTypeId._Initialize, $FFFFFF)


### PR DESCRIPTION
Implements an AtStart function that allows registration of functions to be run at startup with a given priority.

This provides a mechanism to initialize systems and modules in a controlled order, ensuring dependencies are met.

Fixed reflection build issue on arm64.
Added reflection init to startup queue.