### PR TITLE
Improves string equality comparison

### DIFF
--- a/blitz.mod/blitz_string.c
+++ b/blitz.mod/blitz_string.c
@@ -148,11 +148,11 @@ BBULONG bbStringHash( BBString * x ) {
 int bbStringEquals( BBString *x,BBString *y ){
 	if (x->clas != &bbStringClass || y->clas != &bbStringClass) return 0; // only strings with strings
 
-	if (x->length-y->length != 0) return 0;
-	if (x->hash != 0 ) {
-		if (!y->hash) bbStringHash(y);
-		return (x->hash == y->hash);
-	}
+	if (x == y) return 1;
+	if (x->length != y->length) return 0;
+	
+	if (x->hash && y->hash && x->hash != y->hash) return 0;
+
 	return memcmp(x->buf, y->buf, x->length * sizeof(BBChar)) == 0;
 }
 

--- a/blitz.mod/blitz_string.h
+++ b/blitz.mod/blitz_string.h
@@ -212,12 +212,12 @@ inline BBULONG bbStringHash( BBString * x ) {
 
 inline int bbStringEquals( BBString *x,BBString *y ){
 	if (x->clas != (BBClass *)&bbStringClass || y->clas != (BBClass *)&bbStringClass) return 0; // only strings with strings
+	
+	if (x == y) return 1;
+	if (x->length != y->length) return 0;
+	
+	if (x->hash && y->hash && x->hash != y->hash) return 0;
 
-	if (x->length-y->length != 0) return 0;
-	if (x->hash != 0 ) {
-		if (!y->hash) bbStringHash(y);
-		return (x->hash == y->hash);
-	}
 	return memcmp(x->buf, y->buf, x->length * sizeof(BBChar)) == 0;
 }
 


### PR DESCRIPTION
Optimizes the string equality check by adding a fast-path for identical strings and by performing hash comparisons before resorting to a full memory comparison. This reduces unnecessary memory comparisons.