### PR TITLE
Fixed TLinkedList size issue

### DIFF
--- a/collections.mod/linkedlist.bmx
+++ b/collections.mod/linkedlist.bmx
@@ -444,8 +444,9 @@ Private
 				head = node.nextNode
 			End If
 			node.Clear()
-			size :- 1
 		End If
+		
+		size :- 1
 	End Method
 	
 	Method CreateHead(node:TLinkedListNode<T>)


### PR DESCRIPTION
Example:
```
Framework BRL.Blitz
Import BRL.Collections
Import BRL.StandardIO

Local list:TLinkedList<String> = New TLinkedList<String>()
list.AddLast("hello")

Print list.Count()

For Local str:String = EachIn list
	Print str
Next

Print

list.Remove("hello")

Print list.Count()

For Local str:String = EachIn list
	Print str
Next
```