### PR TITLE
Renames Hash() to HashCode()

### DIFF
--- a/stringbuilder.mod/common.bmx
+++ b/stringbuilder.mod/common.bmx
@@ -81,7 +81,7 @@ Extern
 	Function bmx_stringbuilder_format_float(buffer:Byte Ptr, formatText:String, value:Float)
 	Function bmx_stringbuilder_format_double(buffer:Byte Ptr, formatText:String, value:Double)
 	Function bmx_stringbuilder_equals:Int(buffer:Byte Ptr, other:Byte Ptr)
-	Function bmx_stringbuilder_hash:ULong(buffer:Byte Ptr)
+	Function bmx_stringbuilder_hashcode:UInt(buffer:Byte Ptr)
 	Function bmx_stringbuilder_append_utf32string(buffer:Byte Ptr, chars:UInt Ptr)
 	Function bmx_stringbuilder_append_utf32bytes(buffer:Byte Ptr, chars:UInt Ptr, length:Int)
 	Function bmx_stringbuilder_toint:Int(buffer:Byte Ptr)

--- a/stringbuilder.mod/glue.c
+++ b/stringbuilder.mod/glue.c
@@ -655,7 +655,7 @@ int bmx_stringbuilder_equals(struct MaxStringBuilder * buf1, struct MaxStringBui
 		return 1;
 	}
 	if (buf1->count-buf2->count != 0) return 0;
-	if (buf1->hash > 0 && buf1->hash == buf2->hash) return 1;
+	if (buf1->hash != 0 && buf2->hash != 0 && buf1->hash != buf2->hash) return 0;
 	return memcmp(buf1->buffer, buf2->buffer, buf1->count * sizeof(BBChar)) == 0;
 }
 
@@ -947,9 +947,10 @@ void bmx_stringbuilder_format_double(struct MaxStringBuilder * buf, BBString * f
 	bmx_stringbuilder_append_utf8string(buf, buffer);
 }
 
-BBULONG bmx_stringbuilder_hash(struct MaxStringBuilder * buf) {
+BBUINT bmx_stringbuilder_hashcode(struct MaxStringBuilder * buf) {
 	if (buf->hash > 0) return buf->hash;
-	buf->hash = XXH3_64bits(buf->buffer, buf->count * sizeof(BBChar));
+	BBULONG hash = XXH3_64bits(buf->buffer, buf->count * sizeof(BBChar));
+	buf->hash = (BBUINT)(hash ^ (hash >> 32));
 	return buf->hash;
 }
 

--- a/stringbuilder.mod/glue.h
+++ b/stringbuilder.mod/glue.h
@@ -27,7 +27,7 @@ struct MaxStringBuilder {
 	BBChar * buffer;
 	int count;
 	int capacity;
-	BBULONG hash;
+	BBUINT hash;
 };
 
 struct MaxSplitBuffer {
@@ -100,7 +100,7 @@ void bmx_stringbuilder_format_ulong(struct MaxStringBuilder * buf, BBString * fo
 void bmx_stringbuilder_format_sizet(struct MaxStringBuilder * buf, BBString * formatText, BBSIZET value);
 void bmx_stringbuilder_format_float(struct MaxStringBuilder * buf, BBString * formatText, float value);
 void bmx_stringbuilder_format_double(struct MaxStringBuilder * buf, BBString * formatText, double value);
-BBULONG bmx_stringbuilder_hash(struct MaxStringBuilder * buf);
+BBUINT bmx_stringbuilder_hashcode(struct MaxStringBuilder * buf);
 void bmx_stringbuilder_append_utf32string(struct MaxStringBuilder * buf, BBUINT * chars);
 void bmx_stringbuilder_append_utf32bytes(struct MaxStringBuilder * buf, BBUINT * chars, int length);
 int bmx_stringbuilder_toint(struct MaxStringBuilder * buf);

--- a/stringbuilder.mod/stringbuilder.bmx
+++ b/stringbuilder.mod/stringbuilder.bmx
@@ -23,10 +23,12 @@ bbdoc: A string builder.
 End Rem	
 Module BRL.StringBuilder
 
-ModuleInfo "Version: 1.20"
+ModuleInfo "Version: 1.21"
 ModuleInfo "License: zlib/libpng"
 ModuleInfo "Copyright: 2018-2025 Bruce A Henderson"
 
+ModuleInfo "History: 1.21"
+ModuleInfo "History: Changed Hash() to HashCode() to match new Object method."
 ModuleInfo "History: 1.20"
 ModuleInfo "History: Added ToNumber methods."
 ModuleInfo "History: 1.19"
@@ -657,8 +659,8 @@ Public
 	Rem
 	bbdoc: Returns the calculated hash for the content of the string builder.
 	End Rem
-	Method Hash:ULong()
-		Return bmx_stringbuilder_hash(buffer)
+	Method HashCode:UInt() Override
+		Return bmx_stringbuilder_hashcode(buffer)
 	End Method
 	
 	Rem


### PR DESCRIPTION
Renames the `Hash()` method to `HashCode()` to align with the naming conventions of the new Object method.

Updates the hash calculation to use a UInt.