### PR TITLE
Moves generic maps to separate modules

### DIFF
--- a/intmap.mod/intmap.bmx
+++ b/intmap.mod/intmap.bmx
@@ -1,7 +1,25 @@
 SuperStrict
 
+Rem
+bbdoc: Data structures/IntMap
+about: A maps data structure with Int keys.
+End Rem
+Module BRL.IntMap
+
+ModuleInfo "Version: 1.13"
+ModuleInfo "License: zlib/libpng"
+ModuleInfo "Copyright: 2019-2025 Bruce A Henderson"
+
+ModuleInfo "History: 1.13"
+ModuleInfo "History: Moved generic-based maps to their own modules."
+ModuleInfo "History: 1.12"
+ModuleInfo "History: Refactored tree based maps to use brl.collections."
+
 Import BRL.Collections
 
+Rem
+bbdoc: A Tree map backed map with Int keys and Object values.
+End Rem
 Type TIntMap
 	
 	Field _map:TTreeMap<Int, Object> = New TTreeMap<Int, Object>()

--- a/map.mod/common.bmx
+++ b/map.mod/common.bmx
@@ -1,8 +1,0 @@
-SuperStrict
-
-Struct SavlRoot
-	Field left:SavlRoot Ptr
-	Field right:SavlRoot Ptr
-	Field parent:SavlRoot Ptr
-	Field balance:Int
-End Struct

--- a/map.mod/map.bmx
+++ b/map.mod/map.bmx
@@ -6,12 +6,14 @@ bbdoc: Data structures/Maps
 End Rem
 Module BRL.Map
 
-ModuleInfo "Version: 1.12"
+ModuleInfo "Version: 1.13"
 ModuleInfo "Author: Mark Sibly"
 ModuleInfo "License: zlib/libpng"
 ModuleInfo "Copyright: Blitz Research Ltd"
 ModuleInfo "Modserver: BRL"
 
+ModuleInfo "History: 1.13"
+ModuleInfo "History: Moved generic-based maps to their own modules."
 ModuleInfo "History: 1.12"
 ModuleInfo "History: Refactored tree based maps to use brl.collections."
 ModuleInfo "History: 1.11"
@@ -37,11 +39,6 @@ ModuleInfo "History: Finally changed to red/back tree!"
 ModuleInfo "History: Added procedural interface"
 ModuleInfo "History: 1.02 Release"
 ModuleInfo "History: Fixed TMap.Remove:TNode not returning node"
-
-Import "intmap.bmx"
-Import "ptrmap.bmx"
-Import "stringmap.bmx"
-Import "objectmap.bmx"
 
 Private
 

--- a/objectmap.mod/objectmap.bmx
+++ b/objectmap.mod/objectmap.bmx
@@ -1,7 +1,25 @@
 SuperStrict
 
+Rem
+bbdoc: Data structures/ObjectMap
+about: A maps data structure with Object keys.
+End Rem
+Module BRL.ObjectMap
+
+ModuleInfo "Version: 1.13"
+ModuleInfo "License: zlib/libpng"
+ModuleInfo "Copyright: 2019-2025 Bruce A Henderson"
+
+ModuleInfo "History: 1.13"
+ModuleInfo "History: Moved generic-based maps to their own modules."
+ModuleInfo "History: 1.12"
+ModuleInfo "History: Refactored tree based maps to use brl.collections."
+
 Import BRL.Collections
 
+Rem
+bbdoc: A Tree map backed map with Object keys and Object values.
+End Rem
 Type TObjectMap
 
 	Field _map:TTreeMap<Object, Object> = New TTreeMap<Object, Object>()

--- a/ptrmap.mod/ptrmap.bmx
+++ b/ptrmap.mod/ptrmap.bmx
@@ -1,7 +1,24 @@
 SuperStrict
 
+Rem
+bbdoc: Data structures/PtrMap
+End Rem
+Module BRL.PtrMap
+
+ModuleInfo "Version: 1.13"
+ModuleInfo "License: zlib/libpng"
+ModuleInfo "Copyright: 2019-2025 Bruce A Henderson"
+
+ModuleInfo "History: 1.13"
+ModuleInfo "History: Moved generic-based maps to their own modules."
+ModuleInfo "History: 1.12"
+ModuleInfo "History: Refactored tree based maps to use brl.collections."
+
 Import BRL.Collections
 
+Rem
+bbdoc: A Tree map backed map with Byte Ptr keys and Object values.
+End Rem
 Type TPtrMap
 
 	Field _map:TTreeMap<Byte Ptr, Object> = New TTreeMap<Byte Ptr, Object>()

--- a/ptrmap.mod/ptrmap.bmx
+++ b/ptrmap.mod/ptrmap.bmx
@@ -2,6 +2,7 @@ SuperStrict
 
 Rem
 bbdoc: Data structures/PtrMap
+about: A maps data structure with Byte Ptr keys.
 End Rem
 Module BRL.PtrMap
 

--- a/reflection.mod/reflection.bmx
+++ b/reflection.mod/reflection.bmx
@@ -40,6 +40,8 @@ ModuleInfo "History: Fixed NewArray using temp type name"
 
 Import BRL.LinkedList
 Import BRL.Map
+Import BRL.PtrMap
+Import BRL.StringMap
 Import BRL.Threads
 Import "reflection.c"
 

--- a/stringmap.mod/stringmap.bmx
+++ b/stringmap.mod/stringmap.bmx
@@ -1,7 +1,24 @@
 SuperStrict
 
+Rem
+bbdoc: Data structures/StringMap
+End Rem
+Module BRL.StringMap
+
+ModuleInfo "Version: 1.13"
+ModuleInfo "License: zlib/libpng"
+ModuleInfo "Copyright: 2019-2025 Bruce A Henderson"
+
+ModuleInfo "History: 1.13"
+ModuleInfo "History: Moved generic-based maps to their own modules."
+ModuleInfo "History: 1.12"
+ModuleInfo "History: Refactored tree based maps to use brl.collections."
+
 Import BRL.Collections
 
+Rem
+bbdoc: A Tree map backed map with String keys and Object values.
+End Rem
 Type TStringMap
 	
 	Field _map:TTreeMap<String, Object> = New TTreeMap<String, Object>()

--- a/stringmap.mod/stringmap.bmx
+++ b/stringmap.mod/stringmap.bmx
@@ -2,6 +2,7 @@ SuperStrict
 
 Rem
 bbdoc: Data structures/StringMap
+about: A maps data structure with String keys.
 End Rem
 Module BRL.StringMap
 


### PR DESCRIPTION
Splits generic-based map implementations into their own modules to improve code organization and maintainability.

This change separates IntMap, ObjectMap, PtrMap, and StringMap into their respective modules, and updates the main Map module and Reflection module to reflect these changes.