### PR TITLE
Adds fixed-point formatting option for floats and doubles

### DIFF
--- a/blitz.mod/blitz_classes.i
+++ b/blitz.mod/blitz_classes.i
@@ -37,8 +37,8 @@ String^Object{
 
 	+FromInt:String( intValue:Int)="bbStringFromInt"
 	+FromLong:String( longValue:Long )="bbStringFromLong"
-	+FromFloat:String( floatValue:Float )="bbStringFromFloat"
-	+FromDouble:String( doubleValue:Double )="bbStringFromDouble"
+	+FromFloat:String( floatValue:Float, fixed:Int=0 )="bbStringFromFloat"
+	+FromDouble:String( doubleValue:Double, fixed:Int=0 )="bbStringFromDouble"
 	+FromCString:String( cString:Byte Ptr )="bbStringFromCString"
 	+FromWString:String( wString:Short ptr )="bbStringFromWString"
 	

--- a/blitz.mod/blitz_classes.win32.i
+++ b/blitz.mod/blitz_classes.win32.i
@@ -37,8 +37,8 @@ String^Object{
 
 	+FromInt:String( intValue:Int)="bbStringFromInt"
 	+FromLong:String( longValue:Long )="bbStringFromLong"
-	+FromFloat:String( floatValue:Float )="bbStringFromFloat"
-	+FromDouble:String( doubleValue:Double )="bbStringFromDouble"
+	+FromFloat:String( floatValue:Float, fixed:Int=0 )="bbStringFromFloat"
+	+FromDouble:String( doubleValue:Double, fixed:Int=0 )="bbStringFromDouble"
 	+FromCString:String( cString:Byte Ptr )="bbStringFromCString"
 	+FromWString:String( wString:Short ptr )="bbStringFromWString"
 	

--- a/blitz.mod/blitz_string.c
+++ b/blitz.mod/blitz_string.c
@@ -245,15 +245,23 @@ BBString *bbStringFromULongInt( BBULONGINT n ){
 	return bbStringFromBytes( (unsigned char*)buf,strlen(buf) );
 }
 
-BBString *bbStringFromFloat( float n ){
+BBString *bbStringFromFloat( float n, int fixed ){
 	char buf[64];
-	sprintf( buf,"%#.9g",n );
+	if( fixed ) {
+		sprintf( buf,"%.9f",n );
+	} else {
+		sprintf( buf,"%#.9g",n );
+	}
 	return bbStringFromCString(buf);
 }
 
-BBString *bbStringFromDouble( double n ){
+BBString *bbStringFromDouble( double n, int fixed ){
 	char buf[64];
-	sprintf( buf,"%#.17lg",n );
+	if( fixed ) {
+		sprintf( buf,"%.17f",n );
+	} else {
+		sprintf( buf,"%#.17g",n );
+	}
 	return bbStringFromCString(buf);
 }
 

--- a/blitz.mod/blitz_string.h
+++ b/blitz.mod/blitz_string.h
@@ -60,8 +60,8 @@ struct BBClass_String{
 
 	BBString* (*bbStringFromInt)( int n );
 	BBString* (*bbStringFromLong)( BBInt64 n );
-	BBString* (*bbStringFromFloat)( float n );
-	BBString* (*bbStringFromDouble)( double n );
+	BBString* (*bbStringFromFloat)( float n, int fixed );
+	BBString* (*bbStringFromDouble)( double n, int fixed );
 	BBString* (*bbStringFromCString)( const char *p );
 	BBString* (*bbStringFromWString)( const BBChar *p );
 
@@ -131,8 +131,8 @@ BBString* bbStringFromUInt( unsigned int n );
 BBString*	bbStringFromLong( BBInt64 n );
 BBString*	bbStringFromULong( BBUInt64 n );
 BBString*	bbStringFromSizet( BBSIZET n );
-BBString*bbStringFromFloat( float n );
-BBString*	bbStringFromDouble( double n );
+BBString*bbStringFromFloat( float n, int fixed );
+BBString*	bbStringFromDouble( double n, int fixed );
 BBString*	bbStringFromBytes( const unsigned char *p,int n );
 BBString*	bbStringFromShorts( const unsigned short *p,int n );
 BBString*	bbStringFromInts( const int *p,int n );

--- a/blitz.mod/blitz_types.c
+++ b/blitz.mod/blitz_types.c
@@ -136,8 +136,8 @@ BBSTRING bbConvertToString( struct bbDataDef * data ){
 	case 'z':return bbStringFromSizet( data->z );
 	case 'v':return bbStringFromLongInt( data->v );
 	case 'e':return bbStringFromULongInt( data->e );
-	case 'f':return bbStringFromFloat( data->f );
-	case 'd':return bbStringFromFloat( data->d );
+	case 'f':return bbStringFromFloat( data->f, 0 );
+	case 'd':return bbStringFromFloat( data->d, 0 );
 	case '$':return data->t;
 	}
 	return &bbEmptyString;


### PR DESCRIPTION
Improves string conversion of floating-point numbers by adding an option to use fixed-point notation instead of the default general format.