### PR TITLE
Add AlignOf keyword to query type alignment

### DIFF
--- a/blitz.mod/blitz.bmx
+++ b/blitz.mod/blitz.bmx
@@ -1405,6 +1405,11 @@ keyword: "SizeOf"
 End Rem
 
 Rem
+bbdoc: Alignment, in bytes, of a primitive, struct or object type.
+keyword: "AlignOf"
+End Rem
+
+Rem
 bbdoc: Allocates memory from the stack.
 keyword: "StackAlloc"
 about: This memory is automatically freed on leaving the function where it was created.

--- a/blitz.mod/blitz_memory.h
+++ b/blitz.mod/blitz_memory.h
@@ -22,6 +22,36 @@ void		bbMemMove( void *dst,const void *src,size_t size );
 void bbMemDump(void * mem, int size);
 
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define BB_TARGET_MINGW
+#endif
+
+#if defined(_MSC_VER)
+#ifndef __clang__
+#define BB_TARGET_MSVC
+#endif
+#endif
+
+#if defined(__clang__)
+#define BB_TARGET_CLANG
+#endif
+
+#if defined(__GNUC__)
+#define BB_TARGET_GNU
+#endif
+
+#ifdef __cplusplus
+#define bbAlignOf(T) static_cast<size_t>(alignof(T))
+#elif defined(BB_TARGET_MSVC)
+#define bbAlignOf(T) (size_t)__alignof(T)
+#elif defined(BB_TARGET_GNU)
+#define bbAlignOf(T) (size_t)__alignof__(T)
+#elif defined(BB_TARGET_CLANG)
+#define bbAlignOf(T) (size_t)__alignof__(T)
+#else
+#define bbAlignOf(T) ((size_t)&((struct { char c; T d; } *)0)->d)
+#endif
+
 #ifdef _WIN32
 #include <malloc.h>
 #define bbStackAlloc _malloca


### PR DESCRIPTION
Introduce the `AlignOf` keyword and a corresponding `bbAlignOf` macro to determine the memory alignment, in bytes, of a primitive, struct, or object type.