### PR TITLE
Fix TThreadEvent timeout calculation

### DIFF
--- a/threads.mod/threads.bmx
+++ b/threads.mod/threads.bmx
@@ -470,11 +470,11 @@ Type TThreadEvent
         Local endTime:ULong = CurrentUnixTime() + timeoutMs
         While Not _isSet
             Local now:ULong = CurrentUnixTime()
-            If now >= timeoutMs Then
+            If now >= endTime Then
                 lock.Unlock()
                 Return False
             End If
-            condition.TimedWait(lock, Int(timeoutMs - now))
+            condition.TimedWait(lock, Int(endTime - now))
         Wend
         lock.Unlock()
         Return True


### PR DESCRIPTION
`TThreadEvent.Wait(timeout)` compares the current time against the timeout duration instead of the computed deadline, causing timed waits to return immediately. The remaining wait duration is calculated from the timeout value for the same reason.

Fix: Use the computed `endTime` for both the expiry check and the remaining wait duration.

Reproduced on Linux with `Wait(250)` returning after 0 ms before the fix and about 250 ms after the fix. A MaxUnit regression test passed with the fix and failed against the unmodified source.
