### PR TITLE
Fix semaphore timed wait handling

### DIFF
--- a/threads.mod/tests/test.bmx
+++ b/threads.mod/tests/test.bmx
@@ -1,0 +1,35 @@
+SuperStrict
+
+Framework brl.standardio
+Import BRL.Threads
+Import BRL.Time
+Import BRL.System
+Import BRL.MaxUnit
+
+New TTestSuite.run()
+
+Type TSemaphoreTest Extends TTest
+
+	Method TimedWait_HandlesTimeoutAcrossSecondBoundary() { test }
+		Const timeoutMs:Int = 250
+		Const minimumElapsedMs:ULong = 200
+
+		Local phase:ULong = CurrentUnixTime() Mod 1000
+
+		While phase < 800 Or phase >= 900
+			Delay 1
+			phase = CurrentUnixTime() Mod 1000
+		Wend
+
+		Local semaphore:TSemaphore = TSemaphore.Create(0)
+		AssertTrue(semaphore <> Null, "Semaphore creation should succeed")
+
+		Local started:ULong = CurrentUnixTime()
+		Local result:Int = semaphore.TimedWait(timeoutMs)
+		Local elapsed:ULong = CurrentUnixTime() - started
+
+		AssertTrue(elapsed >= minimumElapsedMs, "TimedWait should not return before the timeout expires")
+		AssertEquals(1, result, "TimedWait should report a timeout")
+	End Method
+
+End Type

--- a/threads.mod/threads.c
+++ b/threads.mod/threads.c
@@ -248,13 +248,15 @@ int threads_TimedWaitSemaphore( bb_sem_t *sem, int millisecs ){
 	}
 	
 	ts.tv_sec += millisecs / 1000;
-	ts.tv_nsec += (millisecs % 1000) * 1000000L;
+	BBInt64 nsec = ts.tv_nsec + ((millisecs % 1000) * 1000000L);
+	ts.tv_sec += nsec / 1000000000L;
+	ts.tv_nsec = nsec % 1000000000L;
 	
 	int res = sem_timedwait(sem, &ts);
 	
 	if (res == 0) {
 		return 0;
-	} else if (res == ETIMEDOUT) {
+	} else if (errno == ETIMEDOUT) {
 		return 1;
 	}
 


### PR DESCRIPTION
`TSemaphore.TimedWait()` uses the shared Linux/Haiku `sem_timedwait()` path. The absolute `timespec` is built without normalizing `tv_nsec`, and a timeout is reported through `errno` while the current code compares the return value with `ETIMEDOUT`.

Fix: normalize nanoseconds into `tv_sec` and check `errno` for `ETIMEDOUT`.

The regression test forces a 250 ms timeout across a second boundary. On Linux, the unmodified code fails the test by returning early; with the fix it reports the timeout after about 250 ms.
