### PR TITLE
Add advanced operations and fusion to BRL.Sequence

### DIFF
--- a/sequence.mod/doc/intro.bbdoc
+++ b/sequence.mod/doc/intro.bbdoc
@@ -1,6 +1,6 @@
 BRL.Sequence provides #Sequence<T>, a lazy, strongly typed pipeline over arrays and #IIterable<T> sources.
 
-A Sequence describes how values should be produced. Intermediate operations such as #Sequence.Map, #Sequence.Filter, #Sequence.Take, and #Sequence.Skip do not enumerate the source and do not create intermediate arrays. Enumeration begins only when values are requested by EachIn or a terminal operation.
+A Sequence describes how values should be produced. Intermediate operations such as #Sequence.Map, #Sequence.Filter, #Sequence.FlatMap, #Sequence.TakeWhile, and #Sequence.Concat do not enumerate the source and do not create intermediate arrays. Enumeration begins only when values are requested by EachIn or a terminal operation.
 
 ## Creating a Sequence
 
@@ -40,15 +40,42 @@ The lazy intermediate operations are:
 * #Sequence.Filter retains accepted values.
 * #Sequence.Take limits the number of produced values.
 * #Sequence.Skip omits initial values.
+* #Sequence.FlatMap maps each value to another Sequence and flattens those values.
+* #Sequence.Concat joins two sequences without materializing either one.
+* #Sequence.TakeWhile produces a prefix while its predicate succeeds.
+* #Sequence.SkipWhile omits a prefix while its predicate succeeds.
+* #Sequence.Append and #Sequence.Prepend add one lazily produced endpoint value.
 
 Terminal operations enumerate the pipeline:
 
 * #Sequence.Fold, #Sequence.Count, #Sequence.Any, and #Sequence.All summarize it.
 * #Sequence.FirstOrNone and #Sequence.LastOrNone return BRL.Optional values.
+* #Sequence.ElementAtOrNone returns a value by zero-based position.
+* #Sequence.SingleOrNone succeeds only when exactly one value is produced.
 * #Sequence.ForEach performs an action.
 * #Sequence.ToArray materializes all produced values.
 
 Normal exceptions from user functions propagate unchanged.
+
+## Flattening nested data
+
+#Sequence.FlatMap is useful when each input produces zero or more output values:
+
+```blitzmax
+Function Words:Sequence<String>(line:String)
+	Return Sequence<String>.FromArray(line.Split(" "))
+End Function
+
+Local words:String[] = Sequence<String>.FromArray(lines). ..
+	FlatMap<String>(Words). ..
+	ToArray()
+```
+
+Inner sequences are requested one at a time. Empty inner sequences contribute no values, and an early terminal operation does not request later inner sequences. Replayability and mutation visibility follow both the outer source and every inner Sequence returned by the mapper.
+
+`Concat` likewise waits until its first sequence is exhausted before requesting an iterator from the second sequence.
+
+`TakeWhile` consumes the first value which fails its predicate but does not produce it. `SkipWhile` produces that first failing value and stops testing the predicate thereafter.
 
 ## Repeated enumeration and one-shot sources
 
@@ -63,5 +90,7 @@ Iterator ownership also remains with the source. If a custom iterator owns an ex
 Operators accept both Closures and non-capturing functions. A Closure is convenient when a predicate or mapper needs surrounding local state, but it carries a captured environment and may prevent some compiler optimizations.
 
 For hot pipelines, prefer a named or non-capturing function when practical. The compiler can fuse supported non-capturing Sequence pipelines into direct loops. Capturing Closures remain correct and lazy, but may use the iterator implementation path and cost more dispatch per element.
+
+When a complete `FromArray` pipeline remains visible at a terminal call, the bcc2 compiler can fuse `TakeWhile` and `SkipWhile` with the original `Map`, `Filter`, `Take`, and `Skip` operators into one typed loop. A pipeline stored in a variable, returned from a function, or based on a general iterable retains the ordinary replayable iterator implementation. In particular, #Sequence.FlatMap obtains one inner iterator for every outer value whose mapped sequence is reached. That is an excellent fit for naturally nested or irregular data, but can be substantially more expensive than a hand-written nested loop when every inner sequence is tiny.
 
 For small fixed arrays or very tight game loops, BRL.Arrays or a direct loop may still be the better choice. Measure representative workloads rather than assuming a lazy pipeline is free.

--- a/sequence.mod/sequence.bmx
+++ b/sequence.mod/sequence.bmx
@@ -25,11 +25,13 @@ Module BRL.Sequence
 
 ?bmxng2
 
-ModuleInfo "Version: 1.00"
+ModuleInfo "Version: 1.01"
 ModuleInfo "Author: Bruce A Henderson and contributors"
 ModuleInfo "License: zlib/libpng"
 ModuleInfo "Copyright: 2026 Bruce A Henderson and contributors"
 
+ModuleInfo "History: 1.01"
+ModuleInfo "History: Added FlatMap, Concat, TakeWhile, SkipWhile, Append, Prepend, predicate overloads, additional Optional terminals, and expanded compiler pipeline fusion."
 ModuleInfo "History: 1.00 Initial Release"
 
 Import BRL.Optional
@@ -163,6 +165,92 @@ Type Sequence<T> Implements IIterable<T>
 	Method Skip:Sequence<T>(count:Int)
 		If count < 0 Then count = 0
 		Return New TSkipSequence<T>(Self, count)
+	End Method
+
+	Rem
+	bbdoc: Lazily maps each value to a sequence and yields all inner values in order.
+	param: The Closure invoked once for each outer value as its inner sequence is needed.
+	returns: A lazy flattened Sequence.
+	about: Inner sequences are enumerated one at a time. An inner sequence is not
+	requested until all values from the preceding inner sequence have been consumed.
+	End Rem
+	Method FlatMap<U>:Sequence<U>(mapper:Closure<Sequence<U>(value:T)>)
+		Return New TFlatMapSequence<T, U>(Self, mapper)
+	End Method
+
+	Rem
+	bbdoc: Lazily maps each value to a sequence using a non-capturing function and yields all inner values in order.
+	param: The function invoked once for each outer value as its inner sequence is needed.
+	returns: A lazy flattened Sequence.
+	End Rem
+	Method FlatMap<U>:Sequence<U>(mapper:Sequence<U>(value:T))
+		Return New TFunctionFlatMapSequence<T, U>(Self, mapper)
+	End Method
+
+	Rem
+	bbdoc: Lazily yields this sequence followed by @other.
+	param: The sequence to enumerate after this sequence is exhausted.
+	returns: A lazy concatenated Sequence.
+	about: @other does not receive an iterator until this sequence is exhausted.
+	End Rem
+	Method Concat:Sequence<T>(other:Sequence<T>)
+		Return New TConcatSequence<T>(Self, other)
+	End Method
+
+	Rem
+	bbdoc: Lazily yields values while @predicate returns True.
+	param: The Closure tested for each value until the first rejection.
+	returns: A lazy prefix Sequence.
+	about: The rejecting value is consumed but not yielded. No later value is requested.
+	End Rem
+	Method TakeWhile:Sequence<T>(predicate:Closure<Int(value:T)>)
+		Return New TTakeWhileSequence<T>(Self, predicate)
+	End Method
+
+	Rem
+	bbdoc: Lazily yields values while a non-capturing function returns True.
+	param: The function tested for each value until the first rejection.
+	returns: A lazy prefix Sequence.
+	End Rem
+	Method TakeWhile:Sequence<T>(predicate:Int(value:T))
+		Return New TFunctionTakeWhileSequence<T>(Self, predicate)
+	End Method
+
+	Rem
+	bbdoc: Lazily omits values while @predicate returns True.
+	param: The Closure tested until the first value is rejected.
+	returns: A lazy Sequence beginning with the first rejected value.
+	about: After the first rejection, later values are yielded without invoking @predicate.
+	End Rem
+	Method SkipWhile:Sequence<T>(predicate:Closure<Int(value:T)>)
+		Return New TSkipWhileSequence<T>(Self, predicate)
+	End Method
+
+	Rem
+	bbdoc: Lazily omits values while a non-capturing function returns True.
+	param: The function tested until the first value is rejected.
+	returns: A lazy Sequence beginning with the first rejected value.
+	End Rem
+	Method SkipWhile:Sequence<T>(predicate:Int(value:T))
+		Return New TFunctionSkipWhileSequence<T>(Self, predicate)
+	End Method
+
+	Rem
+	bbdoc: Lazily yields this sequence followed by @value.
+	param: The value to yield after the source is exhausted.
+	returns: A lazy Sequence with one trailing value.
+	End Rem
+	Method Append:Sequence<T>(value:T)
+		Return New TAppendSequence<T>(Self, value)
+	End Method
+
+	Rem
+	bbdoc: Lazily yields @value followed by this sequence.
+	param: The value to yield before the source is requested.
+	returns: A lazy Sequence with one leading value.
+	End Rem
+	Method Prepend:Sequence<T>(value:T)
+		Return New TPrependSequence<T>(Self, value)
 	End Method
 
 	Rem
@@ -354,6 +442,36 @@ Type Sequence<T> Implements IIterable<T>
 			result = Optional<T>.FromValue(iterator.Current())
 		Wend
 		Return result
+	End Method
+
+	Rem
+	bbdoc: Returns the value at zero-based @index, or an undefined Optional when no such value exists.
+	param: The zero-based index of the requested value.
+	returns: An Optional containing the requested value, or an undefined Optional.
+	about: A negative index returns an undefined Optional without requesting an iterator.
+	Enumeration stops as soon as the requested value is found.
+	End Rem
+	Method ElementAtOrNone:Optional<T>(index:Int)
+		If index < 0 Then Return Optional<T>.Undefined()
+		Local iterator:IIterator<T> = GetIterator()
+		While iterator.MoveNext()
+			If index = 0 Then Return Optional<T>.FromValue(iterator.Current())
+			index :- 1
+		Wend
+		Return Optional<T>.Undefined()
+	End Method
+
+	Rem
+	bbdoc: Returns the only value, or an undefined Optional unless the sequence contains exactly one value.
+	returns: An Optional containing the sole value, or an undefined Optional for an empty or multiple-value sequence.
+	about: Enumeration stops after a second value is found.
+	End Rem
+	Method SingleOrNone:Optional<T>()
+		Local iterator:IIterator<T> = GetIterator()
+		If Not iterator.MoveNext() Then Return Optional<T>.Undefined()
+		Local value:T = iterator.Current()
+		If iterator.MoveNext() Then Return Optional<T>.Undefined()
+		Return Optional<T>.FromValue(value)
 	End Method
 
 	Rem
@@ -853,6 +971,675 @@ Type TSkipSequenceIterator<T> Implements IIterator<T>
 			End If
 			_remaining :- 1
 		Wend
+		If Not _source.MoveNext() Then Return False
+		_current = _source.Current()
+		Return True
+	End Method
+End Type
+
+Rem
+bbdoc: Closure-backed flattening pipeline used internally by #Sequence.FlatMap.
+End Rem
+Type TFlatMapSequence<T, U> Extends Sequence<U>
+	Private
+	Field _source:Sequence<T>
+	Field _mapper:Closure<Sequence<U>(value:T)>
+
+	Public
+	Rem
+	bbdoc: Creates a flattening pipeline.
+	param: The outer source sequence.
+	param: The Closure which creates an inner sequence for an outer value.
+	End Rem
+	Method New(source:Sequence<T>, mapper:Closure<Sequence<U>(value:T)>)
+		_source = source
+		_mapper = mapper
+	End Method
+
+	Rem
+	bbdoc: Creates an iterator for this flattening pipeline.
+	returns: A new lazy flattening iterator.
+	End Rem
+	Method GetIterator:IIterator<U>() Override
+		Return New TFlatMapSequenceIterator<T, U>(_source.GetIterator(), _mapper)
+	End Method
+End Type
+
+Rem
+bbdoc: Closure-backed flattening iterator used internally by #TFlatMapSequence.
+End Rem
+Type TFlatMapSequenceIterator<T, U> Implements IIterator<U>
+	Private
+	Field _source:IIterator<T>
+	Field _mapper:Closure<Sequence<U>(value:T)>
+	Field _inner:IIterator<U>
+	Field _hasInner:Int
+	Field _current:U
+
+	Public
+	Rem
+	bbdoc: Creates a flattening iterator.
+	param: The outer source iterator.
+	param: The Closure which creates an inner sequence for an outer value.
+	End Rem
+	Method New(source:IIterator<T>, mapper:Closure<Sequence<U>(value:T)>)
+		_source = source
+		_mapper = mapper
+	End Method
+
+	Rem
+	bbdoc: Returns the current inner value.
+	returns: The value selected by the most recent successful #MoveNext call.
+	End Rem
+	Method Current:U()
+		Return _current
+	End Method
+
+	Rem
+	bbdoc: Advances through the current inner sequence, requesting another only when needed.
+	returns: True when a current value is available; otherwise False.
+	End Rem
+	Method MoveNext:Int()
+		While True
+			If _hasInner And _inner.MoveNext() Then
+				_current = _inner.Current()
+				Return True
+			End If
+			If Not _source.MoveNext() Then Return False
+			Local inner:Sequence<U> = _mapper(_source.Current())
+			_inner = inner.GetIterator()
+			_hasInner = True
+		Wend
+	End Method
+End Type
+
+Rem
+bbdoc: Non-capturing function flattening pipeline used internally by #Sequence.FlatMap.
+End Rem
+Type TFunctionFlatMapSequence<T, U> Extends Sequence<U>
+	Private
+	Field _source:Sequence<T>
+	Field _mapper:Sequence<U>(value:T)
+
+	Public
+	Rem
+	bbdoc: Creates a non-capturing flattening pipeline.
+	param: The outer source sequence.
+	param: The function which creates an inner sequence for an outer value.
+	End Rem
+	Method New(source:Sequence<T>, mapper:Sequence<U>(value:T))
+		_source = source
+		_mapper = mapper
+	End Method
+
+	Rem
+	bbdoc: Creates an iterator for this flattening pipeline.
+	returns: A new lazy flattening iterator.
+	End Rem
+	Method GetIterator:IIterator<U>() Override
+		Return New TFunctionFlatMapSequenceIterator<T, U>(_source.GetIterator(), _mapper)
+	End Method
+End Type
+
+Rem
+bbdoc: Non-capturing function flattening iterator used internally by #TFunctionFlatMapSequence.
+End Rem
+Type TFunctionFlatMapSequenceIterator<T, U> Implements IIterator<U>
+	Private
+	Field _source:IIterator<T>
+	Field _mapper:Sequence<U>(value:T)
+	Field _inner:IIterator<U>
+	Field _hasInner:Int
+	Field _current:U
+
+	Public
+	Rem
+	bbdoc: Creates a non-capturing flattening iterator.
+	param: The outer source iterator.
+	param: The function which creates an inner sequence for an outer value.
+	End Rem
+	Method New(source:IIterator<T>, mapper:Sequence<U>(value:T))
+		_source = source
+		_mapper = mapper
+	End Method
+
+	Rem
+	bbdoc: Returns the current inner value.
+	returns: The value selected by the most recent successful #MoveNext call.
+	End Rem
+	Method Current:U()
+		Return _current
+	End Method
+
+	Rem
+	bbdoc: Advances through the current inner sequence, requesting another only when needed.
+	returns: True when a current value is available; otherwise False.
+	End Rem
+	Method MoveNext:Int()
+		While True
+			If _hasInner And _inner.MoveNext() Then
+				_current = _inner.Current()
+				Return True
+			End If
+			If Not _source.MoveNext() Then Return False
+			Local inner:Sequence<U> = _mapper(_source.Current())
+			_inner = inner.GetIterator()
+			_hasInner = True
+		Wend
+	End Method
+End Type
+
+Rem
+bbdoc: Concatenating pipeline used internally by #Sequence.Concat.
+End Rem
+Type TConcatSequence<T> Extends Sequence<T>
+	Private
+	Field _first:Sequence<T>
+	Field _second:Sequence<T>
+
+	Public
+	Rem
+	bbdoc: Creates a concatenating pipeline.
+	param: The first sequence.
+	param: The second sequence.
+	End Rem
+	Method New(first:Sequence<T>, second:Sequence<T>)
+		_first = first
+		_second = second
+	End Method
+
+	Rem
+	bbdoc: Creates an iterator for this concatenating pipeline.
+	returns: A new lazy concatenating iterator.
+	End Rem
+	Method GetIterator:IIterator<T>() Override
+		Return New TConcatSequenceIterator<T>(_first.GetIterator(), _second)
+	End Method
+End Type
+
+Rem
+bbdoc: Concatenating iterator used internally by #TConcatSequence.
+End Rem
+Type TConcatSequenceIterator<T> Implements IIterator<T>
+	Private
+	Field _first:IIterator<T>
+	Field _secondSource:Sequence<T>
+	Field _second:IIterator<T>
+	Field _inSecond:Int
+	Field _current:T
+
+	Public
+	Rem
+	bbdoc: Creates a concatenating iterator.
+	param: The first iterator.
+	param: The second sequence, retained until the first iterator is exhausted.
+	End Rem
+	Method New(first:IIterator<T>, second:Sequence<T>)
+		_first = first
+		_secondSource = second
+	End Method
+
+	Rem
+	bbdoc: Returns the current value.
+	returns: The value selected by the most recent successful #MoveNext call.
+	End Rem
+	Method Current:T()
+		Return _current
+	End Method
+
+	Rem
+	bbdoc: Advances the first iterator and then the second iterator.
+	returns: True when a current value is available; otherwise False.
+	End Rem
+	Method MoveNext:Int()
+		If Not _inSecond Then
+			If _first.MoveNext() Then
+				_current = _first.Current()
+				Return True
+			End If
+			_second = _secondSource.GetIterator()
+			_inSecond = True
+		End If
+		If Not _second.MoveNext() Then Return False
+		_current = _second.Current()
+		Return True
+	End Method
+End Type
+
+Rem
+bbdoc: Closure-backed prefix pipeline used internally by #Sequence.TakeWhile.
+End Rem
+Type TTakeWhileSequence<T> Extends Sequence<T>
+	Private
+	Field _source:Sequence<T>
+	Field _predicate:Closure<Int(value:T)>
+
+	Public
+	Rem
+	bbdoc: Creates a Closure-backed prefix pipeline.
+	param: The source sequence.
+	param: The prefix predicate.
+	End Rem
+	Method New(source:Sequence<T>, predicate:Closure<Int(value:T)>)
+		_source = source
+		_predicate = predicate
+	End Method
+
+	Rem
+	bbdoc: Creates an iterator for this prefix pipeline.
+	returns: A new lazy prefix iterator.
+	End Rem
+	Method GetIterator:IIterator<T>() Override
+		Return New TTakeWhileSequenceIterator<T>(_source.GetIterator(), _predicate)
+	End Method
+End Type
+
+Rem
+bbdoc: Closure-backed prefix iterator used internally by #TTakeWhileSequence.
+End Rem
+Type TTakeWhileSequenceIterator<T> Implements IIterator<T>
+	Private
+	Field _source:IIterator<T>
+	Field _predicate:Closure<Int(value:T)>
+	Field _current:T
+	Field _done:Int
+
+	Public
+	Rem
+	bbdoc: Creates a Closure-backed prefix iterator.
+	param: The source iterator.
+	param: The prefix predicate.
+	End Rem
+	Method New(source:IIterator<T>, predicate:Closure<Int(value:T)>)
+		_source = source
+		_predicate = predicate
+	End Method
+
+	Rem
+	bbdoc: Returns the current accepted prefix value.
+	returns: The value selected by the most recent successful #MoveNext call.
+	End Rem
+	Method Current:T()
+		Return _current
+	End Method
+
+	Rem
+	bbdoc: Advances while the predicate accepts source values.
+	returns: True when a current value is available; otherwise False.
+	End Rem
+	Method MoveNext:Int()
+		If _done Or Not _source.MoveNext() Then Return False
+		Local value:T = _source.Current()
+		If Not _predicate(value) Then
+			_done = True
+			Return False
+		End If
+		_current = value
+		Return True
+	End Method
+End Type
+
+Rem
+bbdoc: Non-capturing function prefix pipeline used internally by #Sequence.TakeWhile.
+End Rem
+Type TFunctionTakeWhileSequence<T> Extends Sequence<T>
+	Private
+	Field _source:Sequence<T>
+	Field _predicate:Int(value:T)
+
+	Public
+	Rem
+	bbdoc: Creates a non-capturing function prefix pipeline.
+	param: The source sequence.
+	param: The prefix predicate.
+	End Rem
+	Method New(source:Sequence<T>, predicate:Int(value:T))
+		_source = source
+		_predicate = predicate
+	End Method
+
+	Rem
+	bbdoc: Creates an iterator for this prefix pipeline.
+	returns: A new lazy prefix iterator.
+	End Rem
+	Method GetIterator:IIterator<T>() Override
+		Return New TFunctionTakeWhileSequenceIterator<T>(_source.GetIterator(), _predicate)
+	End Method
+End Type
+
+Rem
+bbdoc: Non-capturing function prefix iterator used internally by #TFunctionTakeWhileSequence.
+End Rem
+Type TFunctionTakeWhileSequenceIterator<T> Implements IIterator<T>
+	Private
+	Field _source:IIterator<T>
+	Field _predicate:Int(value:T)
+	Field _current:T
+	Field _done:Int
+
+	Public
+	Rem
+	bbdoc: Creates a non-capturing function prefix iterator.
+	param: The source iterator.
+	param: The prefix predicate.
+	End Rem
+	Method New(source:IIterator<T>, predicate:Int(value:T))
+		_source = source
+		_predicate = predicate
+	End Method
+
+	Rem
+	bbdoc: Returns the current accepted prefix value.
+	returns: The value selected by the most recent successful #MoveNext call.
+	End Rem
+	Method Current:T()
+		Return _current
+	End Method
+
+	Rem
+	bbdoc: Advances while the predicate accepts source values.
+	returns: True when a current value is available; otherwise False.
+	End Rem
+	Method MoveNext:Int()
+		If _done Or Not _source.MoveNext() Then Return False
+		Local value:T = _source.Current()
+		If Not _predicate(value) Then
+			_done = True
+			Return False
+		End If
+		_current = value
+		Return True
+	End Method
+End Type
+
+Rem
+bbdoc: Closure-backed prefix-skipping pipeline used internally by #Sequence.SkipWhile.
+End Rem
+Type TSkipWhileSequence<T> Extends Sequence<T>
+	Private
+	Field _source:Sequence<T>
+	Field _predicate:Closure<Int(value:T)>
+
+	Public
+	Rem
+	bbdoc: Creates a Closure-backed prefix-skipping pipeline.
+	param: The source sequence.
+	param: The prefix predicate.
+	End Rem
+	Method New(source:Sequence<T>, predicate:Closure<Int(value:T)>)
+		_source = source
+		_predicate = predicate
+	End Method
+
+	Rem
+	bbdoc: Creates an iterator for this prefix-skipping pipeline.
+	returns: A new lazy prefix-skipping iterator.
+	End Rem
+	Method GetIterator:IIterator<T>() Override
+		Return New TSkipWhileSequenceIterator<T>(_source.GetIterator(), _predicate)
+	End Method
+End Type
+
+Rem
+bbdoc: Closure-backed prefix-skipping iterator used internally by #TSkipWhileSequence.
+End Rem
+Type TSkipWhileSequenceIterator<T> Implements IIterator<T>
+	Private
+	Field _source:IIterator<T>
+	Field _predicate:Closure<Int(value:T)>
+	Field _current:T
+	Field _skipping:Int = True
+
+	Public
+	Rem
+	bbdoc: Creates a Closure-backed prefix-skipping iterator.
+	param: The source iterator.
+	param: The prefix predicate.
+	End Rem
+	Method New(source:IIterator<T>, predicate:Closure<Int(value:T)>)
+		_source = source
+		_predicate = predicate
+	End Method
+
+	Rem
+	bbdoc: Returns the current value after prefix skipping has completed.
+	returns: The value selected by the most recent successful #MoveNext call.
+	End Rem
+	Method Current:T()
+		Return _current
+	End Method
+
+	Rem
+	bbdoc: Skips the accepted prefix and then advances normally.
+	returns: True when a current value is available; otherwise False.
+	End Rem
+	Method MoveNext:Int()
+		While _source.MoveNext()
+			Local value:T = _source.Current()
+			If _skipping And _predicate(value) Then Continue
+			_skipping = False
+			_current = value
+			Return True
+		Wend
+		Return False
+	End Method
+End Type
+
+Rem
+bbdoc: Non-capturing function prefix-skipping pipeline used internally by #Sequence.SkipWhile.
+End Rem
+Type TFunctionSkipWhileSequence<T> Extends Sequence<T>
+	Private
+	Field _source:Sequence<T>
+	Field _predicate:Int(value:T)
+
+	Public
+	Rem
+	bbdoc: Creates a non-capturing function prefix-skipping pipeline.
+	param: The source sequence.
+	param: The prefix predicate.
+	End Rem
+	Method New(source:Sequence<T>, predicate:Int(value:T))
+		_source = source
+		_predicate = predicate
+	End Method
+
+	Rem
+	bbdoc: Creates an iterator for this prefix-skipping pipeline.
+	returns: A new lazy prefix-skipping iterator.
+	End Rem
+	Method GetIterator:IIterator<T>() Override
+		Return New TFunctionSkipWhileSequenceIterator<T>(_source.GetIterator(), _predicate)
+	End Method
+End Type
+
+Rem
+bbdoc: Non-capturing function prefix-skipping iterator used internally by #TFunctionSkipWhileSequence.
+End Rem
+Type TFunctionSkipWhileSequenceIterator<T> Implements IIterator<T>
+	Private
+	Field _source:IIterator<T>
+	Field _predicate:Int(value:T)
+	Field _current:T
+	Field _skipping:Int = True
+
+	Public
+	Rem
+	bbdoc: Creates a non-capturing function prefix-skipping iterator.
+	param: The source iterator.
+	param: The prefix predicate.
+	End Rem
+	Method New(source:IIterator<T>, predicate:Int(value:T))
+		_source = source
+		_predicate = predicate
+	End Method
+
+	Rem
+	bbdoc: Returns the current value after prefix skipping has completed.
+	returns: The value selected by the most recent successful #MoveNext call.
+	End Rem
+	Method Current:T()
+		Return _current
+	End Method
+
+	Rem
+	bbdoc: Skips the accepted prefix and then advances normally.
+	returns: True when a current value is available; otherwise False.
+	End Rem
+	Method MoveNext:Int()
+		While _source.MoveNext()
+			Local value:T = _source.Current()
+			If _skipping And _predicate(value) Then Continue
+			_skipping = False
+			_current = value
+			Return True
+		Wend
+		Return False
+	End Method
+End Type
+
+Rem
+bbdoc: Trailing-value pipeline used internally by #Sequence.Append.
+End Rem
+Type TAppendSequence<T> Extends Sequence<T>
+	Private
+	Field _source:Sequence<T>
+	Field _value:T
+
+	Public
+	Rem
+	bbdoc: Creates a trailing-value pipeline.
+	param: The source sequence.
+	param: The trailing value.
+	End Rem
+	Method New(source:Sequence<T>, value:T)
+		_source = source
+		_value = value
+	End Method
+
+	Rem
+	bbdoc: Creates an iterator for this trailing-value pipeline.
+	returns: A new lazy trailing-value iterator.
+	End Rem
+	Method GetIterator:IIterator<T>() Override
+		Return New TAppendSequenceIterator<T>(_source.GetIterator(), _value)
+	End Method
+End Type
+
+Rem
+bbdoc: Trailing-value iterator used internally by #TAppendSequence.
+End Rem
+Type TAppendSequenceIterator<T> Implements IIterator<T>
+	Private
+	Field _source:IIterator<T>
+	Field _value:T
+	Field _current:T
+	Field _sourceDone:Int
+	Field _appended:Int
+
+	Public
+	Rem
+	bbdoc: Creates a trailing-value iterator.
+	param: The source iterator.
+	param: The trailing value.
+	End Rem
+	Method New(source:IIterator<T>, value:T)
+		_source = source
+		_value = value
+	End Method
+
+	Rem
+	bbdoc: Returns the current source or trailing value.
+	returns: The value selected by the most recent successful #MoveNext call.
+	End Rem
+	Method Current:T()
+		Return _current
+	End Method
+
+	Rem
+	bbdoc: Advances the source and then yields the trailing value once.
+	returns: True when a current value is available; otherwise False.
+	End Rem
+	Method MoveNext:Int()
+		If Not _sourceDone And _source.MoveNext() Then
+			_current = _source.Current()
+			Return True
+		End If
+		_sourceDone = True
+		If _appended Then Return False
+		_appended = True
+		_current = _value
+		Return True
+	End Method
+End Type
+
+Rem
+bbdoc: Leading-value pipeline used internally by #Sequence.Prepend.
+End Rem
+Type TPrependSequence<T> Extends Sequence<T>
+	Private
+	Field _source:Sequence<T>
+	Field _value:T
+
+	Public
+	Rem
+	bbdoc: Creates a leading-value pipeline.
+	param: The source sequence.
+	param: The leading value.
+	End Rem
+	Method New(source:Sequence<T>, value:T)
+		_source = source
+		_value = value
+	End Method
+
+	Rem
+	bbdoc: Creates an iterator for this leading-value pipeline.
+	returns: A new lazy leading-value iterator.
+	End Rem
+	Method GetIterator:IIterator<T>() Override
+		Return New TPrependSequenceIterator<T>(_source.GetIterator(), _value)
+	End Method
+End Type
+
+Rem
+bbdoc: Leading-value iterator used internally by #TPrependSequence.
+End Rem
+Type TPrependSequenceIterator<T> Implements IIterator<T>
+	Private
+	Field _source:IIterator<T>
+	Field _value:T
+	Field _current:T
+	Field _prepended:Int
+
+	Public
+	Rem
+	bbdoc: Creates a leading-value iterator.
+	param: The source iterator.
+	param: The leading value.
+	End Rem
+	Method New(source:IIterator<T>, value:T)
+		_source = source
+		_value = value
+	End Method
+
+	Rem
+	bbdoc: Returns the current leading or source value.
+	returns: The value selected by the most recent successful #MoveNext call.
+	End Rem
+	Method Current:T()
+		Return _current
+	End Method
+
+	Rem
+	bbdoc: Yields the leading value once and then advances the source.
+	returns: True when a current value is available; otherwise False.
+	End Rem
+	Method MoveNext:Int()
+		If Not _prepended Then
+			_prepended = True
+			_current = _value
+			Return True
+		End If
 		If Not _source.MoveNext() Then Return False
 		_current = _source.Current()
 		Return True

--- a/sequence.mod/tests/second_tier_benchmark.bmx
+++ b/sequence.mod/tests/second_tier_benchmark.bmx
@@ -1,0 +1,108 @@
+SuperStrict
+
+Framework BRL.StandardIO
+Import BRL.Sequence
+Import BRL.System
+
+Const VALUE_COUNT:Int = 200000
+Const ITERATIONS:Int = 50
+
+Function ExpandPair:Sequence<Int>(value:Int)
+	Return Sequence<Int>.FromArray([value, value * 2])
+End Function
+
+Function BelowHalf:Int(value:Int)
+	Return value < VALUE_COUNT / 2
+End Function
+
+Function Add:Long(total:Long, value:Int)
+	Return total + value
+End Function
+
+Local values:Int[] = New Int[VALUE_COUNT]
+For Local index:Int = 0 Until values.Length
+	values[index] = index
+Next
+
+' Warm the relevant generic specializations before measuring.
+Sequence<Int>.FromArray(values).FlatMap<Int>(ExpandPair).Take(2).Count()
+Sequence<Int>.FromArray(values).TakeWhile(BelowHalf).Count()
+Sequence<Int>.FromArray(values).SkipWhile(BelowHalf).Count()
+
+Local eagerFlatChecksum:Long
+Local started:Int = MilliSecs()
+For Local iteration:Int = 0 Until ITERATIONS
+	For Local value:Int = EachIn values
+		eagerFlatChecksum :+ value
+		eagerFlatChecksum :+ value * 2
+	Next
+Next
+Local eagerFlatMilliseconds:Int = MilliSecs() - started
+
+Local lazyFlatChecksum:Long
+started = MilliSecs()
+For Local iteration:Int = 0 Until ITERATIONS
+	lazyFlatChecksum :+ Sequence<Int>.FromArray(values).FlatMap<Int>(ExpandPair).Fold<Long>(Long(0), Add)
+Next
+Local lazyFlatMilliseconds:Int = MilliSecs() - started
+
+Local eagerPrefixCount:Int
+started = MilliSecs()
+For Local iteration:Int = 0 Until ITERATIONS
+	For Local value:Int = EachIn values
+		If Not BelowHalf(value) Then Exit
+		eagerPrefixCount :+ 1
+	Next
+Next
+Local eagerPrefixMilliseconds:Int = MilliSecs() - started
+
+Local storedTakeWhile:Sequence<Int> = Sequence<Int>.FromArray(values).TakeWhile(BelowHalf)
+Local storedPrefixCount:Int
+started = MilliSecs()
+For Local iteration:Int = 0 Until ITERATIONS
+	storedPrefixCount :+ storedTakeWhile.Count()
+Next
+Local storedPrefixMilliseconds:Int = MilliSecs() - started
+
+Local fusedPrefixCount:Int
+started = MilliSecs()
+For Local iteration:Int = 0 Until ITERATIONS
+	fusedPrefixCount :+ Sequence<Int>.FromArray(values).TakeWhile(BelowHalf).Count()
+Next
+Local fusedPrefixMilliseconds:Int = MilliSecs() - started
+
+Local eagerSuffixCount:Int
+started = MilliSecs()
+For Local iteration:Int = 0 Until ITERATIONS
+	Local skipping:Int = True
+	For Local value:Int = EachIn values
+		If skipping And BelowHalf(value) Then Continue
+		skipping = False
+		eagerSuffixCount :+ 1
+	Next
+Next
+Local eagerSuffixMilliseconds:Int = MilliSecs() - started
+
+Local storedSkipWhile:Sequence<Int> = Sequence<Int>.FromArray(values).SkipWhile(BelowHalf)
+Local storedSuffixCount:Int
+started = MilliSecs()
+For Local iteration:Int = 0 Until ITERATIONS
+	storedSuffixCount :+ storedSkipWhile.Count()
+Next
+Local storedSuffixMilliseconds:Int = MilliSecs() - started
+
+Local fusedSuffixCount:Int
+started = MilliSecs()
+For Local iteration:Int = 0 Until ITERATIONS
+	fusedSuffixCount :+ Sequence<Int>.FromArray(values).SkipWhile(BelowHalf).Count()
+Next
+Local fusedSuffixMilliseconds:Int = MilliSecs() - started
+
+Print "BRL.Sequence second-tier benchmark: " + VALUE_COUNT + " values x " + ITERATIONS
+Print "FlatMap eager / lazy:       " + eagerFlatMilliseconds + " / " + lazyFlatMilliseconds + " ms"
+Print "TakeWhile eager/stored/fused: " + eagerPrefixMilliseconds + " / " + storedPrefixMilliseconds + " / " + fusedPrefixMilliseconds + " ms"
+Print "SkipWhile eager/stored/fused: " + eagerSuffixMilliseconds + " / " + storedSuffixMilliseconds + " / " + fusedSuffixMilliseconds + " ms"
+
+If eagerFlatChecksum <> lazyFlatChecksum Then Throw "FlatMap checksum mismatch"
+If eagerPrefixCount <> storedPrefixCount Or eagerPrefixCount <> fusedPrefixCount Then Throw "TakeWhile count mismatch"
+If eagerSuffixCount <> storedSuffixCount Or eagerSuffixCount <> fusedSuffixCount Then Throw "SkipWhile count mismatch"

--- a/sequence.mod/tests/test.bmx
+++ b/sequence.mod/tests/test.bmx
@@ -109,6 +109,20 @@ Function FusionTakeCount:Int()
 	Return 1
 End Function
 
+Function FusionTakeWhilePredicate:Closure<Int(value:Int)>()
+	fusionEvaluationOrder :+ "takeWhile,"
+	Return Function:Int(value:Int)
+		Return value < 10
+	End Function
+End Function
+
+Function FusionSkipWhilePredicate:Closure<Int(value:Int)>()
+	fusionEvaluationOrder :+ "skipWhile,"
+	Return Function:Int(value:Int)
+		Return value < 0
+	End Function
+End Function
+
 Function FusionSeed:Int()
 	fusionEvaluationOrder :+ "seed,"
 	Return 3
@@ -146,6 +160,14 @@ End Function
 Function ThinFail:Int(value:Int)
 	If value = 2 Then Throw "thin failure"
 	Return value
+End Function
+
+Function ExpandPair:Sequence<Int>(value:Int)
+	Return Sequence<Int>.FromArray([value, value * 10])
+End Function
+
+Function LessThanFour:Int(value:Int)
+	Return value < 4
 End Function
 
 Type TSequenceTest Extends TTest
@@ -240,6 +262,47 @@ Type TSequenceTest Extends TTest
 		AssertEquals(4, Sequence<Int>.FromArray([1, 2, 3, 4]).Filter(terminalEven).LastOrNone().Value())
 	End Method
 
+	Method CompilerFusedTakeWhileAndSkipWhilePreservePrefixState() { test }
+		Local takeCalls:Int
+		Local belowThree:Closure<Int(value:Int)> = Function:Int(value:Int)
+			takeCalls :+ 1
+			Return value < 3
+		End Function
+		AssertEquals(2, Sequence<Int>.FromArray([1, 2, 3, 1]).TakeWhile(belowThree).Count())
+		AssertEquals(3, takeCalls, "TakeWhile must test and consume its first rejected value")
+
+		Local mappedCalls:Int
+		Local identity:Closure<Int(value:Int)> = Function:Int(value:Int)
+			mappedCalls :+ 1
+			Return value
+		End Function
+		AssertEquals(2, Sequence<Int>.FromArray([1, 2, 3, 1]).TakeWhile(belowThree).Map<Int>(identity).Count())
+		AssertEquals(2, mappedCalls, "a rejected TakeWhile value must not reach downstream stages")
+
+		Local skipCalls:Int
+		Local skipBelowThree:Closure<Int(value:Int)> = Function:Int(value:Int)
+			skipCalls :+ 1
+			Return value < 3
+		End Function
+		Local skipped:Int[] = Sequence<Int>.FromArray([1, 2, 3, 1]).SkipWhile(skipBelowThree).ToArray()
+		AssertEquals(2, skipped.Length)
+		AssertEquals(3, skipped[0])
+		AssertEquals(1, skipped[1])
+		AssertEquals(3, skipCalls, "SkipWhile must stop invoking its predicate after the first rejection")
+
+		Local upstreamCalls:Int
+		Local alwaysTrue:Closure<Int(value:Int)> = Function:Int(value:Int)
+			upstreamCalls :+ 1
+			Return True
+		End Function
+		AssertEquals(0, Sequence<Int>.FromArray([1, 2, 3]).Take(2).SkipWhile(alwaysTrue).Count())
+		AssertEquals(2, upstreamCalls, "an exhausted upstream Take must stop SkipWhile without another test")
+
+		skipCalls = 0
+		AssertEquals(1, Sequence<Int>.FromArray([1, 2, 3, 4]).SkipWhile(skipBelowThree).Take(1).Count())
+		AssertEquals(3, skipCalls, "a downstream Take must stop after SkipWhile releases its first value")
+	End Method
+
 	Method CompilerFusedFoldRetainsManagedValuesAndExceptions() { test }
 		Local join:Closure<String(total:String, value:String)> = Function:String(total:String, value:String)
 			Return total + value
@@ -261,9 +324,9 @@ Type TSequenceTest Extends TTest
 
 	Method CompilerFusionPreservesReceiverAndArgumentEvaluationOrder() { test }
 		fusionEvaluationOrder = ""
-		Local result:Int = Sequence<Int>.FromArray(FusionValues()).Filter(FusionPredicate()).Take(FusionTakeCount()).Fold<Int>(FusionSeed(), FusionFolder())
+		Local result:Int = Sequence<Int>.FromArray(FusionValues()).Filter(FusionPredicate()).Take(FusionTakeCount()).TakeWhile(FusionTakeWhilePredicate()).SkipWhile(FusionSkipWhilePredicate()).Fold<Int>(FusionSeed(), FusionFolder())
 		AssertEquals(5, result)
-		AssertEquals("source,predicate,take,seed,folder,", fusionEvaluationOrder)
+		AssertEquals("source,predicate,take,takeWhile,skipWhile,seed,folder,", fusionEvaluationOrder)
 	End Method
 
 	Method CompilerFusionRetainsMappedStructAndArrayTypes() { test }
@@ -338,6 +401,200 @@ Type TSequenceTest Extends TTest
 		Local skipped:String[] = pipeline.Skip(1).ToArray()
 		AssertEquals(1, skipped.Length)
 		AssertEquals("v4", skipped[0])
+	End Method
+
+	Method FlatMapIsLazyOrderedAndStopsInsideAnInnerSequence() { test }
+		Local outer:TCountingIterable<Int> = New TCountingIterable<Int>([1, 2, 3])
+		Local first:TCountingIterable<Int> = New TCountingIterable<Int>([10, 11])
+		Local second:TCountingIterable<Int> = New TCountingIterable<Int>([20, 21])
+		Local third:TCountingIterable<Int> = New TCountingIterable<Int>([30, 31])
+		Local mapperCalls:Int
+		Local mapper:Closure<Sequence<Int>(value:Int)> = Function:Sequence<Int>(value:Int)
+			mapperCalls :+ 1
+			Select value
+				Case 1 Return Sequence<Int>.FromIterable(first)
+				Case 2 Return Sequence<Int>.FromIterable(second)
+				Default Return Sequence<Int>.FromIterable(third)
+			End Select
+		End Function
+
+		Local pipeline:Sequence<Int> = Sequence<Int>.FromIterable(outer).FlatMap<Int>(mapper).Take(3)
+		AssertEquals(0, outer.iteratorRequests)
+		AssertEquals(0, mapperCalls)
+		Local values:Int[] = pipeline.ToArray()
+		AssertEquals(3, values.Length)
+		AssertEquals(10, values[0])
+		AssertEquals(11, values[1])
+		AssertEquals(20, values[2])
+		AssertEquals(2, mapperCalls, "FlatMap invokes its mapper once per requested outer value")
+		AssertEquals(2, outer.moveCalls, "FlatMap requests only the outer values needed by Take")
+		AssertEquals(1, first.iteratorRequests)
+		AssertEquals(1, second.iteratorRequests)
+		AssertEquals(0, third.iteratorRequests, "Later inner sequences must not be requested after Take terminates")
+		AssertEquals(3, first.moveCalls, "An exhausted inner sequence includes its terminating probe")
+		AssertEquals(1, second.moveCalls, "Take must not probe beyond its last requested inner value")
+	End Method
+
+	Method FlatMapSupportsNonCapturingFunctionsEmptyInnersAndReplay() { test }
+		Local values:Int[] = Sequence<Int>.FromArray([1, 2]).FlatMap<Int>(ExpandPair).ToArray()
+		AssertEquals(4, values.Length)
+		AssertEquals(1, values[0])
+		AssertEquals(10, values[1])
+		AssertEquals(2, values[2])
+		AssertEquals(20, values[3])
+
+		Local mapper:Closure<Sequence<String>(value:Int)> = Function:Sequence<String>(value:Int)
+			If value = 2 Then Return New Sequence<String>()
+			Return Sequence<String>.FromArray(["v" + value])
+		End Function
+		Local pipeline:Sequence<String> = Sequence<Int>.FromArray([1, 2, 3]).FlatMap<String>(mapper)
+		Local join:Closure<String(total:String, value:String)> = Function:String(total:String, value:String)
+			If total Then Return total + "," + value
+			Return value
+		End Function
+		AssertEquals("v1,v3", pipeline.Fold<String>("", join))
+		AssertEquals(2, pipeline.Count(), "A replayable FlatMap recipe requests fresh outer and inner iterators")
+	End Method
+
+	Method ConcatDefersSecondIteratorAndReplaysBothSources() { test }
+		Local first:TCountingIterable<Int> = New TCountingIterable<Int>([1, 2])
+		Local second:TCountingIterable<Int> = New TCountingIterable<Int>([3, 4])
+		Local combined:Sequence<Int> = Sequence<Int>.FromIterable(first).Concat(Sequence<Int>.FromIterable(second))
+		AssertEquals(0, first.iteratorRequests)
+		AssertEquals(0, second.iteratorRequests)
+		Local iterator:IIterator<Int> = combined.GetIterator()
+		AssertEquals(1, first.iteratorRequests)
+		AssertEquals(0, second.iteratorRequests)
+		AssertTrue(iterator.MoveNext())
+		AssertEquals(1, iterator.Current())
+		AssertTrue(iterator.MoveNext())
+		AssertEquals(2, iterator.Current())
+		AssertEquals(0, second.iteratorRequests)
+		AssertTrue(iterator.MoveNext())
+		AssertEquals(3, iterator.Current())
+		AssertEquals(1, second.iteratorRequests)
+		AssertEquals(4, combined.Count())
+		AssertEquals(2, first.iteratorRequests)
+		AssertEquals(2, second.iteratorRequests)
+	End Method
+
+	Method TakeWhileAndSkipWhileHavePrefixSemantics() { test }
+		Local takeSource:TCountingIterable<Int> = New TCountingIterable<Int>([1, 2, 4, 3])
+		Local takeCalls:Int
+		Local belowFour:Closure<Int(value:Int)> = Function:Int(value:Int)
+			takeCalls :+ 1
+			Return value < 4
+		End Function
+		Local taken:Int[] = Sequence<Int>.FromIterable(takeSource).TakeWhile(belowFour).ToArray()
+		AssertEquals(2, taken.Length)
+		AssertEquals(1, taken[0])
+		AssertEquals(2, taken[1])
+		AssertEquals(3, takeCalls)
+		AssertEquals(3, takeSource.moveCalls, "TakeWhile consumes its rejecting value but nothing after it")
+
+		Local skipSource:TCountingIterable<Int> = New TCountingIterable<Int>([1, 2, 4, 3])
+		Local skipCalls:Int
+		Local skipBelowFour:Closure<Int(value:Int)> = Function:Int(value:Int)
+			skipCalls :+ 1
+			Return value < 4
+		End Function
+		Local skipped:Int[] = Sequence<Int>.FromIterable(skipSource).SkipWhile(skipBelowFour).ToArray()
+		AssertEquals(2, skipped.Length)
+		AssertEquals(4, skipped[0])
+		AssertEquals(3, skipped[1])
+		AssertEquals(3, skipCalls, "SkipWhile stops invoking its predicate after the first rejection")
+		AssertEquals(4, Sequence<Int>.FromArray([1, 2, 4, 3]).SkipWhile(LessThanFour).FirstOrNone().Value())
+		AssertEquals(2, Sequence<Int>.FromArray([1, 2, 4, 3]).TakeWhile(LessThanFour).Count())
+	End Method
+
+	Method AppendAndPrependPreserveOrderAndManagedNullValues() { test }
+		Local values:Int[] = Sequence<Int>.FromArray([2, 3]).Prepend(1).Append(4).ToArray()
+		AssertEquals(4, values.Length)
+		For Local index:Int = 0 Until values.Length
+			AssertEquals(index + 1, values[index])
+		Next
+		AssertEquals(9, New Sequence<Int>().Append(9).SingleOrNone().Value())
+		AssertEquals(8, New Sequence<Int>().Prepend(8).SingleOrNone().Value())
+
+		Local marker:TSequenceMarker
+		Local appended:Optional<TSequenceMarker> = New Sequence<TSequenceMarker>().Append(marker).SingleOrNone()
+		AssertTrue(appended.HasValue())
+		AssertNull(appended.Value())
+	End Method
+
+	Method ElementAtAndSingleStopAsSoonAsTheirAnswerIsKnown() { test }
+		Local negative:TCountingIterable<Int> = New TCountingIterable<Int>([1, 2])
+		AssertTrue(Sequence<Int>.FromIterable(negative).ElementAtOrNone(-1).IsUndefined())
+		AssertEquals(0, negative.iteratorRequests)
+
+		Local found:TCountingIterable<Int> = New TCountingIterable<Int>([4, 5, 6])
+		AssertEquals(5, Sequence<Int>.FromIterable(found).ElementAtOrNone(1).Value())
+		AssertEquals(2, found.moveCalls)
+		Local missing:TCountingIterable<Int> = New TCountingIterable<Int>([4, 5])
+		AssertTrue(Sequence<Int>.FromIterable(missing).ElementAtOrNone(3).IsUndefined())
+		AssertEquals(3, missing.moveCalls)
+
+		AssertTrue(New Sequence<Int>().SingleOrNone().IsUndefined())
+		AssertEquals(7, Sequence<Int>.FromArray([7]).SingleOrNone().Value())
+		Local multiple:TCountingIterable<Int> = New TCountingIterable<Int>([7, 8, 9])
+		AssertTrue(Sequence<Int>.FromIterable(multiple).SingleOrNone().IsUndefined())
+		AssertEquals(2, multiple.moveCalls, "SingleOrNone stops after proving that a second value exists")
+	End Method
+
+	Method SecondTierOperatorsPreserveComplexGenericTypes() { test }
+		Local expandArray:Closure<Sequence<Int>(value:Int[])> = Function:Sequence<Int>(value:Int[])
+			Return Sequence<Int>.FromArray(value)
+		End Function
+		Local flattened:Int[] = Sequence<Int[]>.FromArray([[1, 2], New Int[0], [3]]).FlatMap<Int>(expandArray).ToArray()
+		AssertEquals(3, flattened.Length)
+		AssertEquals(3, flattened[2])
+
+		Local first:SSequencePoint
+		first.x = 4
+		Local second:SSequencePoint
+		second.x = 5
+		Local points:SSequencePoint[] = Sequence<SSequencePoint>.FromArray([first]).Concat(Sequence<SSequencePoint>.FromArray([second])).ToArray()
+		AssertEquals(4, points[0].x)
+		AssertEquals(5, points[1].x)
+
+		Local interfaceValue:ISequenceMarker = New TSequenceInterfaceMarker(23)
+		AssertEquals(23, New Sequence<ISequenceMarker>().Append(interfaceValue).SingleOrNone().Value().Value())
+		Local nested:Optional<Int> = Optional<Int>.FromValue(29)
+		AssertEquals(29, New Sequence<Optional<Int>>().Prepend(nested).ElementAtOrNone(0).Value().Value())
+	End Method
+
+	Method SecondTierClosureExceptionsPropagateUnchanged() { test }
+		Local flattenFailure:Closure<Sequence<Int>(value:Int)> = Function:Sequence<Int>(value:Int)
+			If value = 2 Then Throw "flat-map failure"
+			Return Sequence<Int>.FromArray([value])
+		End Function
+		Local caught:String
+		Try
+			Sequence<Int>.FromArray([1, 2, 3]).FlatMap<Int>(flattenFailure).Count()
+		Catch message:String
+			caught = message
+		End Try
+		AssertEquals("flat-map failure", caught)
+
+		Local predicateFailure:Closure<Int(value:Int)> = Function:Int(value:Int)
+			If value = 2 Then Throw "prefix failure"
+			Return True
+		End Function
+		caught = ""
+		Try
+			Sequence<Int>.FromArray([1, 2, 3]).TakeWhile(predicateFailure).Count()
+		Catch message:String
+			caught = message
+		End Try
+		AssertEquals("prefix failure", caught)
+
+		caught = ""
+		Try
+			Sequence<Int>.FromArray([1, 2, 3]).SkipWhile(predicateFailure).Count()
+		Catch message:String
+			caught = message
+		End Try
+		AssertEquals("prefix failure", caught)
 	End Method
 
 	Method TakeZeroAndNegativeDoNotAdvanceSource() { test }


### PR DESCRIPTION
Introduces FlatMap, Concat, TakeWhile, SkipWhile, Append, and Prepend for more flexible lazy transformations. Adds ElementAtOrNone and SingleOrNone as new Optional-returning terminal operations. Expands compiler pipeline fusion, especially for TakeWhile and SkipWhile.