### PR TITLE
Fix POSIX thread initialization error checks

### DIFF
--- a/blitz.mod/blitz_thread.c
+++ b/blitz.mod/blitz_thread.c
@@ -332,8 +332,8 @@ static BBThread *threads;
 static pthread_key_t curThreadTls;
 
 void bbThreadPreStartup(){
-	if( pthread_mutexattr_init( &_bb_mutexattr )<0 ) exit(-1);
-	if( pthread_mutexattr_settype( &_bb_mutexattr,MUTEX_RECURSIVE )<0 ) exit(-1);
+	if( pthread_mutexattr_init( &_bb_mutexattr )!=0 ) exit(-1);
+	if( pthread_mutexattr_settype( &_bb_mutexattr,MUTEX_RECURSIVE )!=0 ) exit(-1);
 #if __APPLE__
 	// can fail on 10.13 or lower, which we ignore
 	pthread_mutexattr_setpolicy_np(&_bb_mutexattr, MUTEX_POLICY_FIRSTFIT);
@@ -342,9 +342,9 @@ void bbThreadPreStartup(){
 
 void bbThreadStartup(){
 
-	if( pthread_key_create( &curThreadTls,0 )<0 ) exit(-1);
+	if( pthread_key_create( &curThreadTls,0 )!=0 ) exit(-1);
 
-	if( bb_mutex_init( &_bbLock )<0 ) exit(-1);
+	if( !bb_mutex_init( &_bbLock ) ) exit(-1);
 		
 	BBThread *thread=(BBThread *)GC_MALLOC_UNCOLLECTABLE( sizeof( BBThread ) );
 	memset( thread->data,0,sizeof(thread->data) );

--- a/blitz.mod/blitz_thread.h
+++ b/blitz.mod/blitz_thread.h
@@ -58,7 +58,7 @@ typedef Semaphore bb_sem_t;
 typedef pthread_t bb_thread_t;
 typedef pthread_mutex_t bb_mutex_t;
 extern pthread_mutexattr_t _bb_mutexattr;
-#define bb_mutex_init(MUTPTR) (pthread_mutex_init((MUTPTR),&_bb_mutexattr)>=0)
+#define bb_mutex_init(MUTPTR) (pthread_mutex_init((MUTPTR),&_bb_mutexattr)==0)
 #define bb_mutex_destroy(MUTPTR) pthread_mutex_destroy(MUTPTR)
 #define bb_mutex_lock(MUTPTR) pthread_mutex_lock(MUTPTR)
 #define bb_mutex_unlock(MUTPTR) pthread_mutex_unlock(MUTPTR)

--- a/threads.mod/threads.c
+++ b/threads.mod/threads.c
@@ -188,7 +188,7 @@ void threads_BroadcastCond( cnd_t *cond ){
 
 pthread_cond_t *threads_CreateCond(){
 	pthread_cond_t *cond=malloc( sizeof( pthread_cond_t ) );
-	if( pthread_cond_init( cond,0 )>=0 ) return cond;
+	if( pthread_cond_init( cond,0 )==0 ) return cond;
 	free( cond );
 	return 0;
 }


### PR DESCRIPTION
Several POSIX thread initialization APIs return 0 on success and a positive error number on failure. The current checks use < 0 / >= 0 in a few places, which can therefore treat failures as success.

This change uses the documented success condition consistently:

- check pthread_mutexattr_init() and pthread_mutexattr_settype() for != 0
- check pthread_key_create() for != 0
- make bb_mutex_init() succeed only when pthread_mutex_init() returns 0
- update the corresponding _bbLock startup check for the booleanized helper
- make threads_CreateCond() accept only pthread_cond_init() == 0

The change is limited to the POSIX thread/mutex/condition initialization paths in blitz.mod and threads.mod.