### PR TITLE
Interrupting the hook.

### DIFF
--- a/hook.mod/hook.bmx
+++ b/hook.mod/hook.bmx
@@ -85,9 +85,11 @@ Therefore, hook functions should generally return the @data parameter when finis
 End Rem
 Function RunHooks:Object( id,data:Object )
 
+	Local fast:Int=data<>Null
 	Local hook:THook=hooks[id]
 	While hook
 		data=hook.Func( id,data,hook.context )
+		If fast And Not data Then Return Null
 		hook=hook.succ
 	Wend
 	Return data


### PR DESCRIPTION
Is it perhaps unnecessary? But in my practice, this opportunity was necessary. This is when a queue of functions is created, and it is necessary that only one or more necessary functions from the entire queue work. If the function returns an empty value, then this is a signal to stop the hook execution.